### PR TITLE
Added NodeJS dev container and updated readme

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "NodeJS",
+	"image": "ghcr.io/podkrepi-bg/nodejs-devcontainer:v1.1.0",
+	"forwardPorts": [9229, 5010],
+	"containerEnv": {
+		"DATABASE_URL": "postgres://postgres:postgrespass@host.docker.internal:5432/postgres?schema=api"
+	},
+	"postStartCommand": "yarn",
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"nrwl.angular-console",
+		"esbenp.prettier-vscode",
+		"firsttris.vscode-jest-runner",
+		"dbaeumer.vscode-eslint"
+	],
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+	]
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@
   - <https://nx.dev/>
 
 # Setup Development Environment (recommended)
+To run and develop the module NodeJS 16 is required. If you wish to keep your host clean, it is also possible to develop the module in a Docker container. You can do that by using the [Visual Studio Code](https://code.visualstudio.com/download)'s [Remote Containers extension](https://code.visualstudio.com/docs/remote/containers).
+ - Make sure you have the extension installed
+ - Open the folder of the module in VS Code
+ - Hit `Ctrl`/`Cmd` + `Shift` + `P` -> Remote-Containers: Reopen Folder in Container
 
 ## Install dependencies
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,7 +1138,7 @@
     yargs "15.4.1"
     yargs-parser "20.0.0"
 
-"@ntegral/nestjs-sentry@^3.0.6":
+"@ntegral/nestjs-sentry@3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@ntegral/nestjs-sentry/-/nestjs-sentry-3.0.6.tgz#723f829f15532be8f3064a2df45f5a56b32fd4c5"
   integrity sha512-UfBZeamrRlZ1IukRrNJ/fsJjxVHD9WGAGQ3wwBIlpLNFNHAyj+hedtkAnq8vcRECpndDnKeIH5X84L1pBgo5CQ==


### PR DESCRIPTION
Added the possibility to develop the module in a dev container. If possible, someone running Windows should verify if that setup works on Windows.

Steps to execute:
- Checkout the branch
- Make sure PostgreSQL is running a container already. You can do that by running `docker-compose up pg-db`
- Open the project in the dev container
- Run `yarn dev`
- Verify the module starts correctly