### PR TITLE
Added development configuration setting for the logger

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "image": "ghcr.io/podkrepi-bg/nodejs-devcontainer:v1.1.0",
   "forwardPorts": [9229, 5010],
   "containerEnv": {
-    "DATABASE_URL": "postgres://postgres:postgrespass@host.docker.internal:5432/postgres?schema=api"
+    "DATABASE_URL": "postgres://postgres:postgrespass@host.docker.internal:5432/postgres?schema=api",
+    "NODE_ENV": "development"
   },
   "postStartCommand": "yarn",
   "extensions": [

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -14,8 +14,14 @@ import { setupShutdownHooks } from './config/shutdown.config'
 import { setupHelmet } from './config/helmet.config'
 
 async function bootstrap() {
+  const isDevConfig = process.env.NODE_ENV == 'development'
+  if (isDevConfig) {
+    Logger.warn('Running with development configuration')
+  }
+
   const app = await NestFactory.create(AppModule, {
-    logger: ['debug', 'error', 'log', 'verbose', 'warn'],
+    logger: isDevConfig ?
+      ['debug', 'error', 'log', 'verbose', 'warn'] : ['error', 'log', 'warn'],
   })
   const globalPrefix = 'api'
   app.setGlobalPrefix(globalPrefix)

--- a/manifests/api-headless.yaml
+++ b/manifests/api-headless.yaml
@@ -45,6 +45,8 @@ spec:
           image: ghcr.io/podkrepi-bg/api:master
           imagePullPolicy: Always
           env:
+            - name: NODE_ENV
+              value: production
             - name: PORT
               value: "80"
             - name: TARGET_APP


### PR DESCRIPTION
The logger is currently set to output everything including verbose logging for every request. This is undesired for a production deployment as our logs will be flooded. This PR adds a check on `NODE_ENV` environmental variable to determine whether detailed logging is desired. It also makes sure that the default environment for the dev container is set to development