### PR TITLE
return beneficiery and organizer for getCampaignBySlug

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -65,12 +65,12 @@ export class CampaignService {
             type: true,
             publicData: true,
             person: { select: { id: true, firstName: true, lastName: true } },
-            coordinator: {
-              select: {
-                id: true,
-                person: { select: { id: true, firstName: true, lastName: true } },
-              },
-            },
+          },
+        },
+        coordinator: {
+          select: {
+            id: true,
+            person: { select: { id: true, firstName: true, lastName: true } },
           },
         },
       },

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -38,7 +38,7 @@ export class CampaignService {
           campaignAmountReached += donation.amount
         }
       }
-      campaign["summary"] = [{ "reachedAmount": campaignAmountReached}]
+      campaign['summary'] = [{ reachedAmount: campaignAmountReached }]
       //now remove the unnecessary records in vault and donations from response
       campaign.vaults = []
     }

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -24,10 +24,10 @@ export class CampaignService {
       include: {
         vaults: {
           select: {
-            donations: { select: { amount: true} }
-          }
+            donations: { select: { amount: true } },
+          },
         },
-      }
+      },
     })
 
     //TODO: remove this when Prisma starts supporting nested groupbys
@@ -58,6 +58,22 @@ export class CampaignService {
   async getCampaignBySlug(slug: string): Promise<Campaign> {
     const campaign = await this.prisma.campaign.findFirst({
       where: { slug },
+      include: {
+        beneficiary: {
+          select: {
+            id: true,
+            type: true,
+            publicData: true,
+            person: { select: { id: true, firstName: true, lastName: true } },
+            coordinator: {
+              select: {
+                id: true,
+                person: { select: { id: true, firstName: true, lastName: true } },
+              },
+            },
+          },
+        },
+      },
     })
 
     if (campaign === null) {
@@ -72,8 +88,8 @@ export class CampaignService {
       JOIN donations d on v.id = d.target_vault_id
       WHERE d.status = 'succeeded' and v.campaign_id = ${campaign.id}`
 
-    //the query always return 1 record with the value as number or null if no donations where made yet
-    campaign["summary"] = [{ "reachedAmount": reachedAmount[0]["reached_amount"]}]
+    //the query always returns 1 record with the value as number or null if no donations where made yet
+    campaign['summary'] = [{ reachedAmount: reachedAmount[0]['reached_amount'] }]
 
     return campaign
   }

--- a/apps/api/src/campaign/dto/create-campaign.dto.ts
+++ b/apps/api/src/campaign/dto/create-campaign.dto.ts
@@ -103,8 +103,8 @@ export class CreateCampaignDto {
       startDate: this.startDate,
       endDate: this.endDate,
       vaults: { create: { currency: this.currency } },
-      campaignTypes: { connect: { id: this.campaignTypeId } },
-      beneficiaries: { connect: { id: this.beneficiaryId } },
+      campaignType: { connect: { id: this.campaignTypeId } },
+      beneficiary: { connect: { id: this.beneficiaryId } },
     }
   }
 }

--- a/apps/api/src/campaign/dto/create-campaign.dto.ts
+++ b/apps/api/src/campaign/dto/create-campaign.dto.ts
@@ -99,12 +99,12 @@ export class CreateCampaignDto {
       essence: this.essence,
       currency: this.currency,
       targetAmount: this.targetAmount,
-      coordinatorId: this.coordinatorId,
       startDate: this.startDate,
       endDate: this.endDate,
       vaults: { create: { currency: this.currency } },
       campaignType: { connect: { id: this.campaignTypeId } },
       beneficiary: { connect: { id: this.beneficiaryId } },
+      coordinator: { connect: { id: this.coordinatorId } },
     }
   }
 }

--- a/apps/api/src/domain/generated/campaign/dto/create-campaign.dto.ts
+++ b/apps/api/src/domain/generated/campaign/dto/create-campaign.dto.ts
@@ -2,7 +2,6 @@ export class CreateCampaignDto {
   slug: string
   title: string
   essence: string
-  coordinatorId: string
   description?: string
   targetAmount?: number
   startDate?: Date

--- a/apps/api/src/domain/generated/campaign/dto/update-campaign.dto.ts
+++ b/apps/api/src/domain/generated/campaign/dto/update-campaign.dto.ts
@@ -2,7 +2,6 @@ export class UpdateCampaignDto {
   slug?: string
   title?: string
   essence?: string
-  coordinatorId?: string
   description?: string
   targetAmount?: number
   startDate?: Date

--- a/apps/api/src/domain/generated/campaign/entities/campaign.entity.ts
+++ b/apps/api/src/domain/generated/campaign/entities/campaign.entity.ts
@@ -25,8 +25,8 @@ export class Campaign {
   updatedAt: Date | null
   deletedAt: Date | null
   approvedBy?: Person | null
-  beneficiaries?: Beneficiary
-  campaignTypes?: CampaignType
+  beneficiary?: Beneficiary
+  campaignType?: CampaignType
   vaults?: Vault[]
   incomingTransfers?: Transfer[]
   outgoingTransfers?: Transfer[]

--- a/apps/api/src/domain/generated/campaign/entities/campaign.entity.ts
+++ b/apps/api/src/domain/generated/campaign/entities/campaign.entity.ts
@@ -1,5 +1,6 @@
 import { CampaignState, Currency } from '@prisma/client'
 import { Person } from '../../person/entities/person.entity'
+import { Coordinator } from '../../coordinator/entities/coordinator.entity'
 import { Beneficiary } from '../../beneficiary/entities/beneficiary.entity'
 import { CampaignType } from '../../campaignType/entities/campaignType.entity'
 import { Vault } from '../../vault/entities/vault.entity'
@@ -25,6 +26,7 @@ export class Campaign {
   updatedAt: Date | null
   deletedAt: Date | null
   approvedBy?: Person | null
+  coordinator?: Coordinator
   beneficiary?: Beneficiary
   campaignType?: CampaignType
   vaults?: Vault[]

--- a/apps/api/src/domain/generated/coordinator/entities/coordinator.entity.ts
+++ b/apps/api/src/domain/generated/coordinator/entities/coordinator.entity.ts
@@ -1,5 +1,6 @@
 import { Person } from '../../person/entities/person.entity'
 import { Beneficiary } from '../../beneficiary/entities/beneficiary.entity'
+import { Campaign } from '../../campaign/entities/campaign.entity'
 
 export class Coordinator {
   id: string
@@ -8,4 +9,5 @@ export class Coordinator {
   updatedAt: Date | null
   person?: Person
   beneficiaries?: Beneficiary[]
+  campaigns?: Campaign[]
 }

--- a/migrations/20220119120214_added_coordinator_in_campaign/migration.sql
+++ b/migrations/20220119120214_added_coordinator_in_campaign/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "campaigns" ADD CONSTRAINT "campaigns_coordinator_id_fkey" FOREIGN KEY ("coordinator_id") REFERENCES "coordinators"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -129,8 +129,8 @@ Table Campaign {
   updatedAt DateTime
   deletedAt DateTime
   approvedBy Person
-  beneficiaries Beneficiary [not null]
-  campaignTypes CampaignType [not null]
+  beneficiary Beneficiary [not null]
+  campaignType CampaignType [not null]
   vaults Vault [not null]
   incomingTransfers Transfer [not null]
   outgoingTransfers Transfer [not null]

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -60,6 +60,7 @@ Table Coordinator {
   updatedAt DateTime
   person Person [not null]
   beneficiaries Beneficiary [not null]
+  campaigns Campaign [not null]
 
   Note: 'Coordinator is the person who manages the campaign on behalf of the Beneficiary
 Alias: Organizer'
@@ -129,6 +130,7 @@ Table Campaign {
   updatedAt DateTime
   deletedAt DateTime
   approvedBy Person
+  coordinator Coordinator [not null]
   beneficiary Beneficiary [not null]
   campaignType CampaignType [not null]
   vaults Vault [not null]
@@ -491,6 +493,8 @@ Ref: Beneficiary.companyId > Company.id
 Ref: CampaignType.parentId - CampaignType.id
 
 Ref: Campaign.approvedById > Person.id
+
+Ref: Campaign.coordinatorId > Coordinator.id
 
 Ref: Campaign.beneficiaryId > Beneficiary.id
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -168,8 +168,8 @@ model Campaign {
   updatedAt         DateTime?         @updatedAt @map("updated_at") @db.Timestamptz(6)
   deletedAt         DateTime?         @map("deleted_at") @db.Timestamptz(6)
   approvedBy        Person?           @relation(fields: [approvedById], references: [id])
-  beneficiaries     Beneficiary       @relation(fields: [beneficiaryId], references: [id])
-  campaignTypes     CampaignType      @relation(fields: [campaignTypeId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  beneficiary       Beneficiary       @relation(fields: [beneficiaryId], references: [id])
+  campaignType      CampaignType      @relation(fields: [campaignTypeId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   vaults            Vault[]
   incomingTransfers Transfer[]        @relation("target_campaign")
   outgoingTransfers Transfer[]        @relation("source_campaign")

--- a/schema.prisma
+++ b/schema.prisma
@@ -91,6 +91,7 @@ model Coordinator {
   updatedAt     DateTime?     @updatedAt @map("updated_at") @db.Timestamptz(6)
   person        Person        @relation(fields: [personId], references: [id])
   beneficiaries Beneficiary[]
+  campaigns     Campaign[]
 
   @@map("coordinators")
 }
@@ -168,6 +169,7 @@ model Campaign {
   updatedAt         DateTime?         @updatedAt @map("updated_at") @db.Timestamptz(6)
   deletedAt         DateTime?         @map("deleted_at") @db.Timestamptz(6)
   approvedBy        Person?           @relation(fields: [approvedById], references: [id])
+  coordinator       Coordinator       @relation(fields: [coordinatorId], references: [id])
   beneficiary       Beneficiary       @relation(fields: [beneficiaryId], references: [id])
   campaignType      CampaignType      @relation(fields: [campaignTypeId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   vaults            Vault[]


### PR DESCRIPTION
Motivation: The beneficiery annd organizer info are needed to unblock the Campaigns Details page on frontend.
- getCampaignBySlug now returns Beneficiery and Coordinator
