### PR TITLE
Expenses model api

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -54,7 +54,7 @@ import { TemplateService } from '../email/template.service'
     BeneficiaryModule,
     CityModule,
     HealthModule,
-    ExpensesModule
+    ExpensesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { AccountModule } from '../account/account.module'
 import { HealthModule } from '../health/health.module'
 import { SupportModule } from '../support/support.module'
 import { CampaignModule } from '../campaign/campaign.module'
+import { ExpensesModule } from '../expenses/expenses.module'
 import { AppConfigModule } from '../config/app-config.module'
 import { validationSchema } from '../config/validation.config'
 import { DonationsModule } from '../donations/donations.module'
@@ -53,6 +54,7 @@ import { TemplateService } from '../email/template.service'
     BeneficiaryModule,
     CityModule,
     HealthModule,
+    ExpensesModule
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/city/city.module.ts
+++ b/apps/api/src/city/city.module.ts
@@ -8,4 +8,4 @@ import { PrismaService } from '../prisma/prisma.service'
   controllers: [CityController],
   providers: [CityService, PrismaService],
 })
-export class CityModule {}
+export class CityModule { }

--- a/apps/api/src/domain/generated/expense/dto/create-expense.dto.ts
+++ b/apps/api/src/domain/generated/expense/dto/create-expense.dto.ts
@@ -1,8 +1,10 @@
-import { ExpenseType } from '@prisma/client'
+import { ExpenseType, ExpenseStatus } from '@prisma/client'
 import { ApiProperty } from '@nestjs/swagger'
 
 export class CreateExpenseDto {
   @ApiProperty({ enum: ExpenseType })
   type: ExpenseType
+  @ApiProperty({ enum: ExpenseStatus })
+  status: ExpenseStatus
   description?: string
 }

--- a/apps/api/src/domain/generated/expense/dto/update-expense.dto.ts
+++ b/apps/api/src/domain/generated/expense/dto/update-expense.dto.ts
@@ -1,8 +1,10 @@
-import { ExpenseType } from '@prisma/client'
+import { ExpenseType, ExpenseStatus } from '@prisma/client'
 import { ApiProperty } from '@nestjs/swagger'
 
 export class UpdateExpenseDto {
   @ApiProperty({ enum: ExpenseType })
   type?: ExpenseType
+  @ApiProperty({ enum: ExpenseStatus })
+  status?: ExpenseStatus
   description?: string
 }

--- a/apps/api/src/domain/generated/expense/entities/expense.entity.ts
+++ b/apps/api/src/domain/generated/expense/entities/expense.entity.ts
@@ -10,6 +10,7 @@ export class Expense {
   currency: Currency
   amount: number
   vaultId: string
+  deleted: boolean
   description: string | null
   documentId: string | null
   approvedById: string | null

--- a/apps/api/src/domain/generated/expense/entities/expense.entity.ts
+++ b/apps/api/src/domain/generated/expense/entities/expense.entity.ts
@@ -1,4 +1,4 @@
-import { ExpenseType, Currency } from '@prisma/client'
+import { ExpenseType, ExpenseStatus, Currency } from '@prisma/client'
 import { Vault } from '../../vault/entities/vault.entity'
 import { Person } from '../../person/entities/person.entity'
 import { Document } from '../../document/entities/document.entity'
@@ -6,10 +6,11 @@ import { Document } from '../../document/entities/document.entity'
 export class Expense {
   id: string
   type: ExpenseType
+  status: ExpenseStatus
   currency: Currency
   amount: number
-  description: string | null
   vaultId: string
+  description: string | null
   documentId: string | null
   approvedById: string | null
   vault?: Vault

--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -1,0 +1,1 @@
+export class CreateExpenseDto {}

--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -1,1 +1,65 @@
-export class CreateExpenseDto {}
+import {
+	IsEnum,
+	IsNumber,
+	IsOptional,
+	IsString,
+	MaxLength,
+	MinLength,
+} from 'class-validator'
+import { ApiProperty } from '@nestjs/swagger'
+import { Expose } from 'class-transformer'
+import { Currency, Prisma, ExpenseType, Vault, Person } from '.prisma/client'
+@Expose()
+export class CreateExpenseDto {
+	@ApiProperty()
+	@Expose()
+	type: ExpenseType
+
+	@ApiProperty()
+	@Expose()
+	@IsString()
+	@MinLength(3)
+	@MaxLength(3)
+	@IsEnum(Currency)
+	currency: Currency
+
+	@ApiProperty()
+	@Expose()
+	@IsNumber()
+	amount: number
+
+	@ApiProperty()
+	@Expose()
+	@IsOptional()
+	description: string
+
+	@ApiProperty()
+	@Expose()
+	@IsOptional()
+	vaultId: string
+
+	@ApiProperty()
+	@Expose()
+	@IsOptional()
+	documentId: string
+
+	@ApiProperty()
+	@Expose()
+	@IsOptional()
+	approvedById: string
+
+	@ApiProperty()
+	@Expose()
+	@IsOptional()
+	vault: Vault
+
+	@ApiProperty()
+	@Expose()
+	@IsOptional()
+	approvedBy: Person
+
+	@ApiProperty()
+	@Expose()
+	@IsOptional()
+	document: Document
+}

--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -2,17 +2,21 @@ import {
 	IsEnum,
 	IsNumber,
 	IsOptional,
+	isString,
 	IsString,
+	IsUUID,
 	MaxLength,
 	MinLength,
 } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose } from 'class-transformer'
-import { Currency, Prisma, ExpenseType, Vault, Person } from '.prisma/client'
+import { Currency, Prisma, ExpenseType, } from '.prisma/client'
+
 @Expose()
 export class CreateExpenseDto {
 	@ApiProperty()
 	@Expose()
+	@IsString()
 	type: ExpenseType
 
 	@ApiProperty()
@@ -31,35 +35,51 @@ export class CreateExpenseDto {
 	@ApiProperty()
 	@Expose()
 	@IsOptional()
+	@IsString()
 	description: string
 
 	@ApiProperty()
 	@Expose()
-	@IsOptional()
+	@IsUUID()
 	vaultId: string
 
 	@ApiProperty()
 	@Expose()
+	@IsUUID()
 	@IsOptional()
-	documentId: string
+	documentId?: string
+
 
 	@ApiProperty()
 	@Expose()
+	@IsUUID()
 	@IsOptional()
-	approvedById: string
+	approvedById?: string
 
-	@ApiProperty()
-	@Expose()
-	@IsOptional()
-	vault: Vault
+	// public toEntity(): Prisma.ExpenseCreateInput {
+	// 	return {
+	// 		type: this.type,
+	// 		currency: this.currency,
+	// 		amount: this.amount,
+	// 		description: this.description,
+	// 		vault: { connect: { id: this.vaultId } },
+	// 		documentId: this.documentId,
+	// 		approvedById: this.approvedById
+	// 	}
+	// }
 
-	@ApiProperty()
-	@Expose()
-	@IsOptional()
-	approvedBy: Person
-
-	@ApiProperty()
-	@Expose()
-	@IsOptional()
-	document: Document
 }
+
+//expense->vault ---> one-
+
+// id?: string
+// type: ExpenseType
+// currency?: Currency
+// amount?: number
+// description?: string | null
+// vault: VaultCreateNestedOneWithoutExpensesInput
+// approvedBy?: PersonCreateNestedOneWithoutExpensesInput
+// document?: DocumentCreateNestedOneWithoutExpensesInput
+
+
+

--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -1,73 +1,76 @@
 import {
-	IsEnum,
-	IsNumber,
-	IsOptional,
-	isString,
-	IsString,
-	IsUUID,
-	MaxLength,
-	MinLength,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  isString,
+  IsString,
+  IsUUID,
+  MaxLength,
+  MinLength,
 } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose } from 'class-transformer'
-import { Currency, Prisma, ExpenseType, } from '.prisma/client'
+import { Currency, Prisma, ExpenseType, ExpenseStatus } from '.prisma/client'
 
 @Expose()
 export class CreateExpenseDto {
-	@ApiProperty()
-	@Expose()
-	@IsString()
-	type: ExpenseType
+  @ApiProperty()
+  @Expose()
+  @IsString()
+  type: ExpenseType
 
-	@ApiProperty()
-	@Expose()
-	@IsString()
-	@MinLength(3)
-	@MaxLength(3)
-	@IsEnum(Currency)
-	currency: Currency
+  @ApiProperty()
+  @Expose()
+  @IsString()
+  @MinLength(3)
+  @MaxLength(3)
+  @IsEnum(Currency)
+  currency: Currency
 
-	@ApiProperty()
-	@Expose()
-	@IsNumber()
-	amount: number
+  @ApiProperty()
+  @Expose()
+  @IsNumber()
+  amount: number
 
-	@ApiProperty()
-	@Expose()
-	@IsOptional()
-	@IsString()
-	description: string
+  @ApiProperty()
+  @Expose()
+  @IsString()
+  status: ExpenseStatus
 
-	@ApiProperty()
-	@Expose()
-	@IsUUID()
-	vaultId: string
+  @ApiProperty()
+  @Expose()
+  @IsOptional()
+  @IsString()
+  description: string
 
-	@ApiProperty()
-	@Expose()
-	@IsUUID()
-	@IsOptional()
-	documentId?: string
+  @ApiProperty()
+  @Expose()
+  @IsUUID()
+  vaultId: string
 
+  @ApiProperty()
+  @Expose()
+  @IsUUID()
+  @IsOptional()
+  documentId?: string
 
-	@ApiProperty()
-	@Expose()
-	@IsUUID()
-	@IsOptional()
-	approvedById?: string
+  @ApiProperty()
+  @Expose()
+  @IsUUID()
+  @IsOptional()
+  approvedById?: string
 
-	// public toEntity(): Prisma.ExpenseCreateInput {
-	// 	return {
-	// 		type: this.type,
-	// 		currency: this.currency,
-	// 		amount: this.amount,
-	// 		description: this.description,
-	// 		vault: { connect: { id: this.vaultId } },
-	// 		documentId: this.documentId,
-	// 		approvedById: this.approvedById
-	// 	}
-	// }
-
+  // public toEntity(): Prisma.ExpenseCreateInput {
+  // 	return {
+  // 		type: this.type,
+  // 		currency: this.currency,
+  // 		amount: this.amount,
+  // 		description: this.description,
+  // 		vault: { connect: { id: this.vaultId } },
+  // 		documentId: this.documentId,
+  // 		approvedById: this.approvedById
+  // 	}
+  // }
 }
 
 //expense->vault ---> one-
@@ -80,6 +83,3 @@ export class CreateExpenseDto {
 // vault: VaultCreateNestedOneWithoutExpensesInput
 // approvedBy?: PersonCreateNestedOneWithoutExpensesInput
 // document?: DocumentCreateNestedOneWithoutExpensesInput
-
-
-

--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -59,18 +59,6 @@ export class CreateExpenseDto {
   @IsUUID()
   @IsOptional()
   approvedById?: string
-
-  // public toEntity(): Prisma.ExpenseCreateInput {
-  // 	return {
-  // 		type: this.type,
-  // 		currency: this.currency,
-  // 		amount: this.amount,
-  // 		description: this.description,
-  // 		vault: { connect: { id: this.vaultId } },
-  // 		documentId: this.documentId,
-  // 		approvedById: this.approvedById
-  // 	}
-  // }
 }
 
 //expense->vault ---> one-

--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -2,7 +2,6 @@ import {
   IsEnum,
   IsNumber,
   IsOptional,
-  isString,
   IsString,
   IsUUID,
   MaxLength,
@@ -10,7 +9,7 @@ import {
 } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose } from 'class-transformer'
-import { Currency, Prisma, ExpenseType, ExpenseStatus } from '.prisma/client'
+import { Currency, ExpenseType, ExpenseStatus } from '.prisma/client'
 
 @Expose()
 export class CreateExpenseDto {

--- a/apps/api/src/expenses/dto/create-expense.dto.ts
+++ b/apps/api/src/expenses/dto/create-expense.dto.ts
@@ -59,14 +59,3 @@ export class CreateExpenseDto {
   @IsOptional()
   approvedById?: string
 }
-
-//expense->vault ---> one-
-
-// id?: string
-// type: ExpenseType
-// currency?: Currency
-// amount?: number
-// description?: string | null
-// vault: VaultCreateNestedOneWithoutExpensesInput
-// approvedBy?: PersonCreateNestedOneWithoutExpensesInput
-// document?: DocumentCreateNestedOneWithoutExpensesInput

--- a/apps/api/src/expenses/dto/update-expense.dto.ts
+++ b/apps/api/src/expenses/dto/update-expense.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateExpenseDto } from './create-expense.dto';
+
+export class UpdateExpenseDto extends PartialType(CreateExpenseDto) {}

--- a/apps/api/src/expenses/dto/update-expense.dto.ts
+++ b/apps/api/src/expenses/dto/update-expense.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateExpenseDto } from './create-expense.dto';
+import { PartialType } from '@nestjs/swagger'
+import { CreateExpenseDto } from './create-expense.dto'
 
 export class UpdateExpenseDto extends PartialType(CreateExpenseDto) {}

--- a/apps/api/src/expenses/entities/expense.entity.ts
+++ b/apps/api/src/expenses/entities/expense.entity.ts
@@ -1,0 +1,1 @@
+export class Expense {}

--- a/apps/api/src/expenses/entities/expense.entity.ts
+++ b/apps/api/src/expenses/entities/expense.entity.ts
@@ -1,1 +1,1 @@
-export class Expense {}
+export class Expense { }

--- a/apps/api/src/expenses/expenses.controller.spec.ts
+++ b/apps/api/src/expenses/expenses.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExpensesController } from './expenses.controller';
+import { ExpensesService } from './expenses.service';
+
+describe('ExpensesController', () => {
+  let controller: ExpensesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExpensesController],
+      providers: [ExpensesService],
+    }).compile();
+
+    controller = module.get<ExpensesController>(ExpensesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/expenses/expenses.controller.spec.ts
+++ b/apps/api/src/expenses/expenses.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { ExpensesController } from './expenses.controller'
 import { ExpensesService } from './expenses.service'
+import { PrismaService } from '../prisma/prisma.service'
+
 
 describe('ExpensesController', () => {
   let controller: ExpensesController
@@ -8,7 +10,7 @@ describe('ExpensesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ExpensesController],
-      providers: [ExpensesService],
+      providers: [PrismaService, ExpensesService],
     }).compile()
 
     controller = module.get<ExpensesController>(ExpensesController)

--- a/apps/api/src/expenses/expenses.controller.spec.ts
+++ b/apps/api/src/expenses/expenses.controller.spec.ts
@@ -1,20 +1,20 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ExpensesController } from './expenses.controller';
-import { ExpensesService } from './expenses.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { ExpensesController } from './expenses.controller'
+import { ExpensesService } from './expenses.service'
 
 describe('ExpensesController', () => {
-  let controller: ExpensesController;
+  let controller: ExpensesController
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ExpensesController],
       providers: [ExpensesService],
-    }).compile();
+    }).compile()
 
-    controller = module.get<ExpensesController>(ExpensesController);
-  });
+    controller = module.get<ExpensesController>(ExpensesController)
+  })
 
   it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-});
+    expect(controller).toBeDefined()
+  })
+})

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { ExpensesService } from './expenses.service';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+
+@Controller('expenses')
+export class ExpensesController {
+  constructor(private readonly expensesService: ExpensesService) {}
+
+  @Post()
+  create(@Body() createExpenseDto: CreateExpenseDto) {
+    return this.expensesService.create(createExpenseDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.expensesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.expensesService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateExpenseDto: UpdateExpenseDto) {
+    return this.expensesService.update(+id, updateExpenseDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.expensesService.remove(+id);
+  }
+}

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -7,7 +7,7 @@ import { UpdateExpenseDto } from './dto/update-expense.dto'
 
 @Controller('expenses')
 export class ExpensesController {
-  constructor(private readonly expensesService: ExpensesService) { }
+  constructor(private readonly expensesService: ExpensesService) {}
 
   @Public()
   @Get('list')
@@ -31,8 +31,6 @@ export class ExpensesController {
   @Public()
   @Delete(':id')
   remove(@Param('id') id: string) {
-    // soft delete!
-    // update the status from whatever it is to deleted
-    return this.expensesService.remove(+id)
+    return this.expensesService.remove(id)
   }
 }

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -1,41 +1,35 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
-import { Public } from 'nest-keycloak-connect';
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common'
+import { Public } from 'nest-keycloak-connect'
 
-import { ExpensesService } from './expenses.service';
-import { CreateExpenseDto } from './dto/create-expense.dto';
-import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { ExpensesService } from './expenses.service'
+import { CreateExpenseDto } from './dto/create-expense.dto'
+import { UpdateExpenseDto } from './dto/update-expense.dto'
 
 @Controller('expenses')
 export class ExpensesController {
-  constructor(private readonly expensesService: ExpensesService) { }
+  constructor(private readonly expensesService: ExpensesService) {}
 
   @Public()
   @Get('list')
   async findAll() {
-    return await this.expensesService.listExpenses();
+    return await this.expensesService.listExpenses()
   }
 
   @Public()
   @Post('create-expense')
   create(@Body() createExpenseDto: CreateExpenseDto) {
-    return this.expensesService.createExpense(createExpenseDto);
+    return this.expensesService.createExpense(createExpenseDto)
   }
 
   @Public()
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.expensesService.findOne(+id);
-  }
-
-  @Public()
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateExpenseDto: UpdateExpenseDto) {
-    return this.expensesService.update(+id, updateExpenseDto);
+    return this.expensesService.findOne(+id)
   }
 
   @Public()
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return this.expensesService.remove(+id);
+    return this.expensesService.remove(+id)
   }
 }

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -7,7 +7,7 @@ import { UpdateExpenseDto } from './dto/update-expense.dto'
 
 @Controller('expenses')
 export class ExpensesController {
-  constructor(private readonly expensesService: ExpensesService) {}
+  constructor(private readonly expensesService: ExpensesService) { }
 
   @Public()
   @Get('list')
@@ -32,5 +32,11 @@ export class ExpensesController {
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.expensesService.remove(id)
+  }
+
+  @Public()
+  @Delete()
+  removeMany(@Body() idsToDelete: string[]) {
+    return this.expensesService.removeMany(idsToDelete);
   }
 }

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -17,8 +17,8 @@ export class ExpensesController {
 
   @Public()
   @Get()
-  findAll() {
-    return this.expensesService.findAll();
+  async findAll() {
+    return await this.expensesService.listExpenses();
   }
 
   @Public()

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -1,32 +1,39 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Public } from 'nest-keycloak-connect';
+
 import { ExpensesService } from './expenses.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
 
 @Controller('expenses')
 export class ExpensesController {
-  constructor(private readonly expensesService: ExpensesService) {}
+  constructor(private readonly expensesService: ExpensesService) { }
 
+  @Public()
   @Post()
   create(@Body() createExpenseDto: CreateExpenseDto) {
     return this.expensesService.create(createExpenseDto);
   }
 
+  @Public()
   @Get()
   findAll() {
     return this.expensesService.findAll();
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.expensesService.findOne(+id);
   }
 
+  @Public()
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateExpenseDto: UpdateExpenseDto) {
     return this.expensesService.update(+id, updateExpenseDto);
   }
 
+  @Public()
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.expensesService.remove(+id);

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -10,15 +10,15 @@ export class ExpensesController {
   constructor(private readonly expensesService: ExpensesService) { }
 
   @Public()
-  @Post()
-  create(@Body() createExpenseDto: CreateExpenseDto) {
-    return this.expensesService.create(createExpenseDto);
+  @Get('list')
+  async findAll() {
+    return await this.expensesService.listExpenses();
   }
 
   @Public()
-  @Get()
-  async findAll() {
-    return await this.expensesService.listExpenses();
+  @Post('create-expense')
+  create(@Body() createExpenseDto: CreateExpenseDto) {
+    return this.expensesService.createExpense(createExpenseDto);
   }
 
   @Public()

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -11,7 +11,6 @@ export class ExpensesController {
   @Public()
   @Get('list')
   async findAll() {
-    //filter to return only those who are not deleted
     return await this.expensesService.listExpenses()
   }
 

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -1,9 +1,8 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common'
+import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common'
 import { Public } from 'nest-keycloak-connect'
 
 import { ExpensesService } from './expenses.service'
 import { CreateExpenseDto } from './dto/create-expense.dto'
-import { UpdateExpenseDto } from './dto/update-expense.dto'
 
 @Controller('expenses')
 export class ExpensesController {

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -12,6 +12,7 @@ export class ExpensesController {
   @Public()
   @Get('list')
   async findAll() {
+    //filter to return only those who are not deleted
     return await this.expensesService.listExpenses()
   }
 
@@ -30,6 +31,8 @@ export class ExpensesController {
   @Public()
   @Delete(':id')
   remove(@Param('id') id: string) {
+    // soft delete!
+    // update the status from whatever it is to deleted
     return this.expensesService.remove(+id)
   }
 }

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -7,7 +7,7 @@ import { UpdateExpenseDto } from './dto/update-expense.dto'
 
 @Controller('expenses')
 export class ExpensesController {
-  constructor(private readonly expensesService: ExpensesService) {}
+  constructor(private readonly expensesService: ExpensesService) { }
 
   @Public()
   @Get('list')
@@ -25,7 +25,7 @@ export class ExpensesController {
   @Public()
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.expensesService.findOne(+id)
+    return this.expensesService.findOne(id)
   }
 
   @Public()

--- a/apps/api/src/expenses/expenses.module.ts
+++ b/apps/api/src/expenses/expenses.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ExpensesService } from './expenses.service';
+import { ExpensesController } from './expenses.controller';
+
+@Module({
+  controllers: [ExpensesController],
+  providers: [ExpensesService]
+})
+export class ExpensesModule {}

--- a/apps/api/src/expenses/expenses.module.ts
+++ b/apps/api/src/expenses/expenses.module.ts
@@ -5,6 +5,6 @@ import { PrismaService } from '../prisma/prisma.service'
 
 @Module({
   controllers: [ExpensesController],
-  providers: [ExpensesService, PrismaService],
+  providers: [PrismaService, ExpensesService],
 })
-export class ExpensesModule {}
+export class ExpensesModule { }

--- a/apps/api/src/expenses/expenses.module.ts
+++ b/apps/api/src/expenses/expenses.module.ts
@@ -1,10 +1,10 @@
-import { Module } from '@nestjs/common';
-import { ExpensesService } from './expenses.service';
-import { ExpensesController } from './expenses.controller';
-import { PrismaService } from '../prisma/prisma.service';
+import { Module } from '@nestjs/common'
+import { ExpensesService } from './expenses.service'
+import { ExpensesController } from './expenses.controller'
+import { PrismaService } from '../prisma/prisma.service'
 
 @Module({
   controllers: [ExpensesController],
-  providers: [ExpensesService, PrismaService]
+  providers: [ExpensesService, PrismaService],
 })
-export class ExpensesModule { }
+export class ExpensesModule {}

--- a/apps/api/src/expenses/expenses.module.ts
+++ b/apps/api/src/expenses/expenses.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ExpensesService } from './expenses.service';
 import { ExpensesController } from './expenses.controller';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Module({
   controllers: [ExpensesController],
-  providers: [ExpensesService]
+  providers: [ExpensesService, PrismaService]
 })
-export class ExpensesModule {}
+export class ExpensesModule { }

--- a/apps/api/src/expenses/expenses.service.spec.ts
+++ b/apps/api/src/expenses/expenses.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExpensesService } from './expenses.service';
+
+describe('ExpensesService', () => {
+  let service: ExpensesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExpensesService],
+    }).compile();
+
+    service = module.get<ExpensesService>(ExpensesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/expenses/expenses.service.spec.ts
+++ b/apps/api/src/expenses/expenses.service.spec.ts
@@ -1,12 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { ExpensesService } from './expenses.service'
+import { PrismaService } from '../prisma/prisma.service'
+
 
 describe('ExpensesService', () => {
   let service: ExpensesService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ExpensesService],
+      providers: [PrismaService, ExpensesService],
     }).compile()
 
     service = module.get<ExpensesService>(ExpensesService)

--- a/apps/api/src/expenses/expenses.service.spec.ts
+++ b/apps/api/src/expenses/expenses.service.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ExpensesService } from './expenses.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { ExpensesService } from './expenses.service'
 
 describe('ExpensesService', () => {
-  let service: ExpensesService;
+  let service: ExpensesService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ExpensesService],
-    }).compile();
+    }).compile()
 
-    service = module.get<ExpensesService>(ExpensesService);
-  });
+    service = module.get<ExpensesService>(ExpensesService)
+  })
 
   it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-});
+    expect(service).toBeDefined()
+  })
+})

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+
+@Injectable()
+export class ExpensesService {
+  create(createExpenseDto: CreateExpenseDto) {
+    return 'This action adds a new expense';
+  }
+
+  findAll() {
+    return `This action returns all expenses`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} expense`;
+  }
+
+  update(id: number, updateExpenseDto: UpdateExpenseDto) {
+    return `This action updates a #${id} expense`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} expense`;
+  }
+}

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -1,15 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { PrismaService } from '../prisma/prisma.service'
+import { Expense } from '@prisma/client';
 
 @Injectable()
 export class ExpensesService {
-  create(createExpenseDto: CreateExpenseDto) {
-    return 'This action adds a new expense';
+  constructor(private prisma: PrismaService) { }
+
+  async create(createExpenseDto: CreateExpenseDto) {
+    return "created"
   }
 
-  findAll() {
-    return `This action returns all expenses`;
+  async listExpenses(): Promise<Expense[]> {
+    return this.prisma.expense.findMany()
   }
 
   findOne(id: number) {

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -11,15 +11,13 @@ export class ExpensesService {
     return await this.prisma.expense.create({ data: createExpenseDto })
   }
 
-  async listExpenses(): Promise<Expense[]> {
-    return this.prisma.expense.findMany({ where: { deleted: false } })
+  async listExpenses(returnDeleted = false): Promise<Expense[]> {
+    return this.prisma.expense.findMany({ where: { deleted: returnDeleted } })
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, returnDeleted = false) {
     try {
-      const expense = await this.prisma.expense.findFirst({ where: { id, deleted: false } })
-      // handle what happens if it finds the id but the deleted is true , what do we return to the client?
-      // may be a message saying the expense has been deleted ?
+      const expense = await this.prisma.expense.findFirst({ where: { id, deleted: returnDeleted } })
       return expense
     } catch (error) {
       throw new NotFoundException('No expense found with that id.')

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@nestjs/common';
-import { CreateExpenseDto } from './dto/create-expense.dto';
+import { Injectable } from '@nestjs/common'
+import { CreateExpenseDto } from './dto/create-expense.dto'
 import { PrismaService } from '../prisma/prisma.service'
-import { Expense } from '@prisma/client';
+import { Expense } from '@prisma/client'
 
 @Injectable()
 export class ExpensesService {
-  constructor(private prisma: PrismaService) { }
+  constructor(private prisma: PrismaService) {}
 
   async createExpense(createExpenseDto: CreateExpenseDto) {
     return await this.prisma.expense.create({ data: createExpenseDto })
@@ -16,10 +16,10 @@ export class ExpensesService {
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} expense`;
+    return `This action returns a #${id} expense`
   }
 
   remove(id: number) {
-    return `This action removes a #${id} expense`;
+    return `This action removes a #${id} expense`
   }
 }

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -12,19 +12,25 @@ export class ExpensesService {
   }
 
   async listExpenses(): Promise<Expense[]> {
-    return this.prisma.expense.findMany()
+    return this.prisma.expense.findMany({ where: { deleted: false } })
   }
 
   async findOne(id: string) {
     try {
-      const expense = await this.prisma.expense.findFirst({ where: { id } });
+      const expense = await this.prisma.expense.findFirst({ where: { id, deleted: false } })
+      // handle what happens if it finds the id but the deleted is true , what do we return to the client?
+      // may be a message saying the expense has been deleted ?
       return expense
     } catch (error) {
-      throw new NotFoundException("No expense found with that id.")
+      throw new NotFoundException('No expense found with that id.')
     }
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} expense`
+  async remove(id: string) {
+    try {
+      return await this.prisma.expense.update({ where: { id }, data: { deleted: true } })
+    } catch (error) {
+      throw new NotFoundException('No expense with this id exists.')
+    }
   }
 }

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotFoundException } from '@nestjs/common'
 import { CreateExpenseDto } from './dto/create-expense.dto'
 import { PrismaService } from '../prisma/prisma.service'
 import { Expense } from '@prisma/client'
 
 @Injectable()
 export class ExpensesService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private prisma: PrismaService) { }
 
   async createExpense(createExpenseDto: CreateExpenseDto) {
     return await this.prisma.expense.create({ data: createExpenseDto })
@@ -15,8 +15,13 @@ export class ExpensesService {
     return this.prisma.expense.findMany()
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} expense`
+  async findOne(id: string) {
+    try {
+      const expense = await this.prisma.expense.findFirst({ where: { id } });
+      return expense
+    } catch (error) {
+      throw new NotFoundException("No expense found with that id.")
+    }
   }
 
   remove(id: number) {

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -28,7 +28,7 @@ export class ExpensesService {
 
   async remove(id: string) {
     try {
-      return await this.prisma.expense.update({ where: { id }, data: { deleted: true } })
+      return await this.prisma.expense.delete({ where: { id } })
     } catch (error) {
       throw new NotFoundException('No expense with this id exists.')
     }

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { CreateExpenseDto } from './dto/create-expense.dto';
-import { UpdateExpenseDto } from './dto/update-expense.dto';
 import { PrismaService } from '../prisma/prisma.service'
 import { Expense } from '@prisma/client';
 
@@ -8,8 +7,8 @@ import { Expense } from '@prisma/client';
 export class ExpensesService {
   constructor(private prisma: PrismaService) { }
 
-  async create(createExpenseDto: CreateExpenseDto) {
-    return "created"
+  async createExpense(createExpenseDto: CreateExpenseDto) {
+    return await this.prisma.expense.create({ data: createExpenseDto })
   }
 
   async listExpenses(): Promise<Expense[]> {
@@ -18,10 +17,6 @@ export class ExpensesService {
 
   findOne(id: number) {
     return `This action returns a #${id} expense`;
-  }
-
-  update(id: number, updateExpenseDto: UpdateExpenseDto) {
-    return `This action updates a #${id} expense`;
   }
 
   remove(id: number) {

--- a/apps/api/src/expenses/expenses.service.ts
+++ b/apps/api/src/expenses/expenses.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { CreateExpenseDto } from './dto/create-expense.dto'
 import { PrismaService } from '../prisma/prisma.service'
 import { Expense } from '@prisma/client'
@@ -31,6 +31,22 @@ export class ExpensesService {
       return await this.prisma.expense.update({ where: { id }, data: { deleted: true } })
     } catch (error) {
       throw new NotFoundException('No expense with this id exists.')
+    }
+  }
+
+  async removeMany(idsToDelete: string[]) {
+    try {
+      return await this.prisma.expense.deleteMany({
+        where: {
+          id: {
+            in: idsToDelete
+          }
+        }
+      })
+    } catch (err) {
+      const msg = 'Delete failed. No Expense found with given ID'
+      Logger.warn(msg)
+      throw new NotFoundException(msg)
     }
   }
 }

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -4,6 +4,25 @@ import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common'
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
   async onModuleInit() {
+
+    this.$use(async (params, next) => {
+      if (params.model == 'Expense') {
+        if (params.action == 'delete') {
+          params.action = 'update'
+          params.args['data'] = { deleted: true }
+        }
+        if (params.action == 'deleteMany') {
+          params.action = 'updateMany'
+          if (params.args.data != undefined) {
+            params.args.data['deleted'] = true
+          } else {
+            params.args['data'] = { deleted: true }
+          }
+        }
+      }
+      return next(params)
+    })
+
     await this.$connect()
   }
 

--- a/db/seed/expense.seed.ts
+++ b/db/seed/expense.seed.ts
@@ -42,7 +42,7 @@ export async function expenseSeed() {
         type: ExpenseType.administrative,
         amount: faker.datatype.number({ min: 1, max: 1000 }),
         description: faker.lorem.words(10),
-        status: ExpenseStatus.deleted,
+        status: ExpenseStatus.pending,
         vaultId: vault.id,
       },
       {

--- a/db/seed/expense.seed.ts
+++ b/db/seed/expense.seed.ts
@@ -1,0 +1,100 @@
+import faker from 'faker'
+import { Currency, ExpenseStatus, ExpenseType, PrismaClient } from '@prisma/client'
+const prisma = new PrismaClient()
+
+export async function expenseSeed() {
+  console.log('Expense seed')
+
+  const vault = await prisma.vault.findFirst()
+
+  if (!vault) {
+    throw new Error('There are no vaults created yet!')
+  }
+
+  const insert = await prisma.expense.createMany({
+    data: [
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.legal,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.pending,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.advertising,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.approved,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.rental,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.canceled,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.administrative,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.deleted,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.bank,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.pending,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.internal,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.pending,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.shipping,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.pending,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.transport,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.pending,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.shipping,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.pending,
+        vaultId: vault.id,
+      },
+      {
+        currency: Currency.BGN,
+        type: ExpenseType.services,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        description: faker.lorem.words(10),
+        status: ExpenseStatus.pending,
+        vaultId: vault.id,
+      },
+    ],
+    skipDuplicates: true,
+  })
+  console.log({ insert })
+}

--- a/db/seed/index.ts
+++ b/db/seed/index.ts
@@ -9,6 +9,7 @@ import { coordinatorSeed } from './coordinator.seed'
 import { beneficiarySeed } from './beneficiary.seed'
 import { infoRequestSeed } from './infoRequest.seed'
 import { campaignTypesSeed } from './campaign-type.seed'
+import { vaultSeed } from './vault.seed'
 
 const prisma = new PrismaClient()
 
@@ -25,6 +26,7 @@ async function main() {
       await coordinatorSeed(),
       await beneficiarySeed(),
       await campaignSeed(),
+      await vaultSeed(),
     ])
   }
 }

--- a/db/seed/index.ts
+++ b/db/seed/index.ts
@@ -10,6 +10,7 @@ import { beneficiarySeed } from './beneficiary.seed'
 import { infoRequestSeed } from './infoRequest.seed'
 import { campaignTypesSeed } from './campaign-type.seed'
 import { vaultSeed } from './vault.seed'
+import { expenseSeed } from './expense.seed'
 
 const prisma = new PrismaClient()
 
@@ -27,6 +28,7 @@ async function main() {
       await beneficiarySeed(),
       await campaignSeed(),
       await vaultSeed(),
+      await expenseSeed(),
     ])
   }
 }

--- a/db/seed/vault.seed.ts
+++ b/db/seed/vault.seed.ts
@@ -6,12 +6,10 @@ export async function vaultSeed() {
   console.log('Vault seed')
 
   const campaign = await prisma.campaign.findFirst()
-  // find the first campaign to get its ID so we can create a seed for the vaults and they will all be connected to this campaign for now
 
   if (!campaign) {
     throw new Error('There are no campaigns created yet!')
   }
-  // check if campaigns are created if not throw an error (they are seeded so it should be fine)
 
   const insert = await prisma.vault.createMany({
     data: [
@@ -68,9 +66,6 @@ export async function vaultSeed() {
     ],
     skipDuplicates: true,
   })
-
-  // With this we will create a seed with 10 vaults , random amount , all with BGN currency and all of them are related to the same campaign
-  // campaign->vault  =  one-to-many relationship 1-n
 
   console.log({ insert })
 }

--- a/db/seed/vault.seed.ts
+++ b/db/seed/vault.seed.ts
@@ -1,0 +1,76 @@
+import faker from 'faker'
+import { Currency, PrismaClient } from '@prisma/client'
+const prisma = new PrismaClient()
+
+export async function vaultSeed() {
+  console.log('Vault seed')
+
+  const campaign = await prisma.campaign.findFirst()
+  // find the first campaign to get its ID so we can create a seed for the vaults and they will all be connected to this campaign for now
+
+  if (!campaign) {
+    throw new Error('There are no campaigns created yet!')
+  }
+  // check if campaigns are created if not throw an error (they are seeded so it should be fine)
+
+  const insert = await prisma.vault.createMany({
+    data: [
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+      {
+        currency: Currency.BGN,
+        amount: faker.datatype.number({ min: 1, max: 1000 }),
+        campaignId: campaign.id,
+      },
+    ],
+    skipDuplicates: true,
+  })
+
+  // With this we will create a seed with 10 vaults , random amount , all with BGN currency and all of them are related to the same campaign
+  // campaign->vault  =  one-to-many relationship 1-n
+
+  console.log({ insert })
+}

--- a/migrations/20220206100839_added_expense_status/migration.sql
+++ b/migrations/20220206100839_added_expense_status/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `status` to the `expenses` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "ExpenseStatus" AS ENUM ('pending', 'approved', 'canceled', 'deleted');
+
+-- AlterTable
+ALTER TABLE "expenses" ADD COLUMN     "status" "ExpenseStatus" NOT NULL;

--- a/migrations/20220207070106_add_delete_boolean_for_expense/migration.sql
+++ b/migrations/20220207070106_add_delete_boolean_for_expense/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The values [deleted] on the enum `ExpenseStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "ExpenseStatus_new" AS ENUM ('pending', 'approved', 'canceled');
+ALTER TABLE "expenses" ALTER COLUMN "status" TYPE "ExpenseStatus_new" USING ("status"::text::"ExpenseStatus_new");
+ALTER TYPE "ExpenseStatus" RENAME TO "ExpenseStatus_old";
+ALTER TYPE "ExpenseStatus_new" RENAME TO "ExpenseStatus";
+DROP TYPE "ExpenseStatus_old";
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "expenses" ADD COLUMN     "deleted" BOOLEAN NOT NULL DEFAULT false;

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -313,10 +313,11 @@ Table BankAccount {
 Table Expense {
   id String [pk]
   type ExpenseType [not null]
+  status ExpenseStatus [not null]
   currency Currency [not null, default: 'BGN']
   amount Int [not null, default: 0]
-  description String
   vaultId String [not null]
+  description String
   documentId String
   approvedById String
   vault Vault [not null]
@@ -383,6 +384,13 @@ Enum Currency {
   BGN
   EUR
   USD
+}
+
+Enum ExpenseStatus {
+  pending
+  approved
+  canceled
+  deleted
 }
 
 Enum ExpenseType {

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -317,6 +317,7 @@ Table Expense {
   currency Currency [not null, default: 'BGN']
   amount Int [not null, default: 0]
   vaultId String [not null]
+  deleted Boolean [not null, default: false]
   description String
   documentId String
   approvedById String
@@ -390,7 +391,6 @@ Enum ExpenseStatus {
   pending
   approved
   canceled
-  deleted
 }
 
 Enum ExpenseType {

--- a/schema.prisma
+++ b/schema.prisma
@@ -386,10 +386,11 @@ model BankAccount {
 model Expense {
   id           String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   type         ExpenseType
+  status       ExpenseStatus 
   currency     Currency    @default(BGN)
   amount       Int         @default(0) @db.Integer
-  description  String?
   vaultId      String      @map("vault_id") @db.Uuid
+  description  String?
   documentId   String?     @map("document_id") @db.Uuid
   approvedById String?     @db.Uuid
   vault        Vault       @relation(fields: [vaultId], references: [id])
@@ -469,6 +470,13 @@ enum Currency {
   USD
 
   @@map("currency")
+}
+
+enum ExpenseStatus {
+  pending
+  approved
+  canceled
+  deleted
 }
 
 enum ExpenseType {

--- a/schema.prisma
+++ b/schema.prisma
@@ -390,10 +390,11 @@ model Expense {
   currency     Currency    @default(BGN)
   amount       Int         @default(0) @db.Integer
   vaultId      String      @map("vault_id") @db.Uuid
+  deleted      Boolean     @default(false)
   description  String?
   documentId   String?     @map("document_id") @db.Uuid
   approvedById String?     @db.Uuid
-  vault        Vault       @relation(fields: [vaultId], references: [id])
+  vault        Vault       @relation(fields: [vaultId], references: [id]) 
   approvedBy   Person?     @relation(fields: [approvedById], references: [id])
   document     Document?   @relation(fields: [documentId], references: [id])
 
@@ -476,7 +477,6 @@ enum ExpenseStatus {
   pending
   approved
   canceled
-  deleted
 }
 
 enum ExpenseType {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80568052/152826718-4904f266-76d3-458a-bb4f-6c1cdea0cba1.png)

- GET /api/expenses/list -> lists all the expenses that don't have their deleted boolean to true , a.k.a all expenses that are not deleted.
-GET /api/expenses/id -> returns the data for the special expense with the provided ID
- POST /api/expenses -> create a new expense , by far at the front end I wont be showing the option to connect with documentID and approvedById
- DELETE /api/expenses/id -> soft deleting the passed id (making the deleted boolean to true , yet we still have it in the DB we just dont list it because of our GET /api/expenses/list filter.
- DELETE /api/expenses -> same as the above one , just with the difference that we accept an array with ID's as strings.
- Created a middleware in prisma.service file to make the soft delete possible
- Created seed for vaults which is the parent of the expenses 
- Created seed for expenses , they are all connected to one of the vaults by hardcoding them with the firstly found from the base
- Campaign > Vaults > Expenses , so I created the Vault seed  as an array to the campaign but also they contain array with expenses.
- There is not an update/edit endpoint since logically changing an expense would be illegal?