### PR TITLE
Vault entity crud

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { CountryModule } from '../country/country.module'
 import { CompanyModule } from '../company/company.module'
 import { InfoRequestModule } from '../info-request/info-request.module'
 import { BankAccountModule } from '../bankaccount/bankaccount.module'
+import { VaultModule } from '../vault/vault.module'
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { BankAccountModule } from '../bankaccount/bankaccount.module'
     InfoRequestModule,
     BankAccountModule,
     ExpensesModule,
+    VaultModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -17,7 +17,7 @@ import { CreateCampaignDto } from './dto/create-campaign.dto'
 
 @Injectable()
 export class CampaignService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private prisma: PrismaService) { }
 
   async listCampaigns(): Promise<Campaign[]> {
     const campaigns = await this.prisma.campaign.findMany({
@@ -127,9 +127,9 @@ export class CampaignService {
     const vault = await this.getCampaignVault(campaignId)
     const targetVault = vault
       ? // Connect the existing vault to this donation
-        { connect: { id: vault.id } }
+      { connect: { id: vault.id } }
       : // Create new vault for the campaign
-        { create: { campaignId, currency, amount } }
+      { create: { campaignId, currency, amount, name: 'Това е примерно име' } }
 
     /**
      * Create donation object

--- a/apps/api/src/campaign/dto/create-campaign.dto.ts
+++ b/apps/api/src/campaign/dto/create-campaign.dto.ts
@@ -101,7 +101,7 @@ export class CreateCampaignDto {
       targetAmount: this.targetAmount,
       startDate: this.startDate,
       endDate: this.endDate,
-      vaults: { create: { currency: this.currency } },
+      vaults: { create: { currency: this.currency, name: 'Това е примерно име' } },
       campaignType: { connect: { id: this.campaignTypeId } },
       beneficiary: { connect: { id: this.beneficiaryId } },
       coordinator: { connect: { id: this.coordinatorId } },

--- a/apps/api/src/domain/generated/vault/dto/create-vault.dto.ts
+++ b/apps/api/src/domain/generated/vault/dto/create-vault.dto.ts
@@ -1,1 +1,3 @@
-export class CreateVaultDto {}
+export class CreateVaultDto {
+  name: string
+}

--- a/apps/api/src/domain/generated/vault/dto/update-vault.dto.ts
+++ b/apps/api/src/domain/generated/vault/dto/update-vault.dto.ts
@@ -1,1 +1,3 @@
-export class UpdateVaultDto {}
+export class UpdateVaultDto {
+  name?: string
+}

--- a/apps/api/src/domain/generated/vault/entities/vault.entity.ts
+++ b/apps/api/src/domain/generated/vault/entities/vault.entity.ts
@@ -8,6 +8,7 @@ import { RecurringDonation } from '../../recurringDonation/entities/recurringDon
 
 export class Vault {
   id: string
+  name: string
   currency: Currency
   amount: number
   campaignId: string

--- a/apps/api/src/vault/dto/create-vault.dto.ts
+++ b/apps/api/src/vault/dto/create-vault.dto.ts
@@ -1,0 +1,1 @@
+export class CreateVaultDto {}

--- a/apps/api/src/vault/dto/create-vault.dto.ts
+++ b/apps/api/src/vault/dto/create-vault.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger'
 import {
-  Campaign,
   Currency,
   Donation,
   Expense,

--- a/apps/api/src/vault/dto/create-vault.dto.ts
+++ b/apps/api/src/vault/dto/create-vault.dto.ts
@@ -10,7 +10,7 @@ import {
   Withdrawal,
 } from '@prisma/client'
 import { Expose } from 'class-transformer'
-import { IsDate, IsNumber, IsOptional, IsPositive, IsString, IsUUID } from 'class-validator'
+import { IsOptional, IsString, IsUUID } from 'class-validator'
 
 @Expose()
 export class CreateVaultDto {
@@ -22,11 +22,6 @@ export class CreateVaultDto {
   @IsString()
   @ApiProperty()
   name: string
-
-  @Expose()
-  @IsNumber()
-  @ApiProperty()
-  amount: number
 
   @Expose()
   @ApiProperty()
@@ -68,7 +63,7 @@ export class CreateVaultDto {
     return {
       currency: this.currency,
       name: this.name,
-      amount: this.amount,
+      amount: 0,
       createdAt: new Date(),
       updatedAt: null,
       campaign: {

--- a/apps/api/src/vault/dto/create-vault.dto.ts
+++ b/apps/api/src/vault/dto/create-vault.dto.ts
@@ -1,15 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger'
 import {
   Currency,
-  Donation,
-  Expense,
   Prisma,
-  RecurringDonation,
-  Transfer,
-  Withdrawal,
 } from '@prisma/client'
 import { Expose } from 'class-transformer'
-import { IsOptional, IsString, IsUUID } from 'class-validator'
+import { IsString, IsUUID } from 'class-validator'
 
 @Expose()
 export class CreateVaultDto {
@@ -27,36 +22,6 @@ export class CreateVaultDto {
   @IsString()
   @IsUUID()
   campaignId: string
-
-  @Expose()
-  @ApiProperty()
-  @IsOptional()
-  expenses?: Expense[]
-
-  @Expose()
-  @ApiProperty()
-  @IsOptional()
-  sourceTransfers?: Transfer[]
-
-  @Expose()
-  @ApiProperty()
-  @IsOptional()
-  targetTransfers?: Transfer[]
-
-  @Expose()
-  @ApiProperty()
-  @IsOptional()
-  donations?: Donation[]
-
-  @Expose()
-  @ApiProperty()
-  @IsOptional()
-  withdraws?: Withdrawal[]
-
-  @Expose()
-  @ApiProperty()
-  @IsOptional()
-  recurringDonations?: RecurringDonation[]
 
   public toEntity(): Prisma.VaultCreateInput {
     return {

--- a/apps/api/src/vault/dto/create-vault.dto.ts
+++ b/apps/api/src/vault/dto/create-vault.dto.ts
@@ -1,1 +1,81 @@
-export class CreateVaultDto {}
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  Campaign,
+  Currency,
+  Donation,
+  Expense,
+  Prisma,
+  RecurringDonation,
+  Transfer,
+  Withdrawal,
+} from '@prisma/client'
+import { Expose } from 'class-transformer'
+import { IsDate, IsNumber, IsOptional, IsPositive, IsString, IsUUID } from 'class-validator'
+
+@Expose()
+export class CreateVaultDto {
+  @Expose()
+  @ApiProperty({ enum: Currency })
+  currency: Currency
+
+  @Expose()
+  @IsString()
+  @ApiProperty()
+  name: string
+
+  @Expose()
+  @IsNumber()
+  @ApiProperty()
+  amount: number
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsUUID()
+  campaignId: string
+
+  @Expose()
+  @ApiProperty()
+  @IsOptional()
+  expenses?: Expense[]
+
+  @Expose()
+  @ApiProperty()
+  @IsOptional()
+  sourceTransfers?: Transfer[]
+
+  @Expose()
+  @ApiProperty()
+  @IsOptional()
+  targetTransfers?: Transfer[]
+
+  @Expose()
+  @ApiProperty()
+  @IsOptional()
+  donations?: Donation[]
+
+  @Expose()
+  @ApiProperty()
+  @IsOptional()
+  withdraws?: Withdrawal[]
+
+  @Expose()
+  @ApiProperty()
+  @IsOptional()
+  recurringDonations?: RecurringDonation[]
+
+  public toEntity(): Prisma.VaultCreateInput {
+    return {
+      currency: this.currency,
+      name: this.name,
+      amount: this.amount,
+      createdAt: new Date(),
+      updatedAt: null,
+      campaign: {
+        connect: {
+          id: this.campaignId,
+        },
+      },
+    }
+  }
+}

--- a/apps/api/src/vault/dto/update-vault.dto.ts
+++ b/apps/api/src/vault/dto/update-vault.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateVaultDto } from './create-vault.dto';
+
+export class UpdateVaultDto extends PartialType(CreateVaultDto) {}

--- a/apps/api/src/vault/dto/update-vault.dto.ts
+++ b/apps/api/src/vault/dto/update-vault.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateVaultDto } from './create-vault.dto';
+import { PartialType } from '@nestjs/swagger'
+import { CreateVaultDto } from './create-vault.dto'
 
 export class UpdateVaultDto extends PartialType(CreateVaultDto) {}

--- a/apps/api/src/vault/dto/update-vault.dto.ts
+++ b/apps/api/src/vault/dto/update-vault.dto.ts
@@ -1,4 +1,10 @@
-import { PartialType } from '@nestjs/swagger'
-import { CreateVaultDto } from './create-vault.dto'
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
+import { IsString } from "class-validator";
 
-export class UpdateVaultDto extends PartialType(CreateVaultDto) {}
+export class UpdateVaultDto {
+    @Expose()
+    @IsString()
+    @ApiProperty()
+    name?: string
+}

--- a/apps/api/src/vault/entities/vault.entity.ts
+++ b/apps/api/src/vault/entities/vault.entity.ts
@@ -1,0 +1,1 @@
+export class Vault {}

--- a/apps/api/src/vault/entities/vault.entity.ts
+++ b/apps/api/src/vault/entities/vault.entity.ts
@@ -1,15 +1,8 @@
-import {
-  Campaign,
-  Currency,
-  Donation,
-  Expense,
-  RecurringDonation,
-  Transfer,
-  Withdrawal,
-} from '@prisma/client'
+import { Campaign, Currency, Donation, Expense, RecurringDonation, Transfer, Withdrawal } from '@prisma/client'
 
 export class Vault {
   id: string
+  name: string
   currency: Currency
   amount: number
   campaignId: string

--- a/apps/api/src/vault/entities/vault.entity.ts
+++ b/apps/api/src/vault/entities/vault.entity.ts
@@ -1,1 +1,25 @@
-export class Vault {}
+import {
+  Campaign,
+  Currency,
+  Donation,
+  Expense,
+  RecurringDonation,
+  Transfer,
+  Withdrawal,
+} from '@prisma/client'
+
+export class Vault {
+  id: string
+  currency: Currency
+  amount: number
+  campaignId: string
+  createdAt: Date
+  updatedAt: Date | null
+  campaign?: Campaign
+  expenses?: Expense[]
+  sourceTransfers?: Transfer[]
+  targetTransfers?: Transfer[]
+  donations?: Donation[]
+  withdraws?: Withdrawal[]
+  recurringDonations?: RecurringDonation[]
+}

--- a/apps/api/src/vault/vault.controller.spec.ts
+++ b/apps/api/src/vault/vault.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VaultController } from './vault.controller';
+import { VaultService } from './vault.service';
+
+describe('VaultController', () => {
+  let controller: VaultController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VaultController],
+      providers: [VaultService],
+    }).compile();
+
+    controller = module.get<VaultController>(VaultController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/vault/vault.controller.spec.ts
+++ b/apps/api/src/vault/vault.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { PrismaService } from '../prisma/prisma.service'
 import { VaultController } from './vault.controller'
 import { VaultService } from './vault.service'
 
@@ -8,7 +9,7 @@ describe('VaultController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [VaultController],
-      providers: [VaultService],
+      providers: [VaultService, PrismaService],
     }).compile()
 
     controller = module.get<VaultController>(VaultController)

--- a/apps/api/src/vault/vault.controller.spec.ts
+++ b/apps/api/src/vault/vault.controller.spec.ts
@@ -1,20 +1,20 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { VaultController } from './vault.controller';
-import { VaultService } from './vault.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { VaultController } from './vault.controller'
+import { VaultService } from './vault.service'
 
 describe('VaultController', () => {
-  let controller: VaultController;
+  let controller: VaultController
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [VaultController],
       providers: [VaultService],
-    }).compile();
+    }).compile()
 
-    controller = module.get<VaultController>(VaultController);
-  });
+    controller = module.get<VaultController>(VaultController)
+  })
 
   it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-});
+    expect(controller).toBeDefined()
+  })
+})

--- a/apps/api/src/vault/vault.controller.spec.ts
+++ b/apps/api/src/vault/vault.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+
 import { PrismaService } from '../prisma/prisma.service'
 import { VaultController } from './vault.controller'
 import { VaultService } from './vault.service'

--- a/apps/api/src/vault/vault.controller.spec.ts
+++ b/apps/api/src/vault/vault.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { CampaignService } from '../campaign/campaign.service'
 
 import { PrismaService } from '../prisma/prisma.service'
 import { VaultController } from './vault.controller'
@@ -10,7 +11,7 @@ describe('VaultController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [VaultController],
-      providers: [VaultService, PrismaService],
+      providers: [VaultService, CampaignService, PrismaService],
     }).compile()
 
     controller = module.get<VaultController>(VaultController)

--- a/apps/api/src/vault/vault.controller.ts
+++ b/apps/api/src/vault/vault.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { VaultService } from './vault.service';
+import { CreateVaultDto } from './dto/create-vault.dto';
+import { UpdateVaultDto } from './dto/update-vault.dto';
+
+@Controller('vault')
+export class VaultController {
+  constructor(private readonly vaultService: VaultService) {}
+
+  @Post()
+  create(@Body() createVaultDto: CreateVaultDto) {
+    return this.vaultService.create(createVaultDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.vaultService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.vaultService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateVaultDto: UpdateVaultDto) {
+    return this.vaultService.update(+id, updateVaultDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.vaultService.remove(+id);
+  }
+}

--- a/apps/api/src/vault/vault.controller.ts
+++ b/apps/api/src/vault/vault.controller.ts
@@ -1,40 +1,78 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common'
+import { Controller, Get, Post, Body, Patch, Param, Delete, UnauthorizedException } from '@nestjs/common'
 import { VaultService } from './vault.service'
 import { CreateVaultDto } from './dto/create-vault.dto'
 import { UpdateVaultDto } from './dto/update-vault.dto'
-import { Public } from 'nest-keycloak-connect'
+import { AuthenticatedUser, Public } from 'nest-keycloak-connect'
+import { KeycloakTokenParsed } from '../auth/keycloak'
 
 @Controller('vault')
 export class VaultController {
-  constructor(private readonly vaultService: VaultService) {}
+  constructor(private readonly vaultService: VaultService) { }
 
   @Public()
   @Post()
-  create(@Body() createVaultDto: CreateVaultDto) {
+  create(@AuthenticatedUser() user: KeycloakTokenParsed,
+    @Body() createVaultDto: CreateVaultDto) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+
     return this.vaultService.create(createVaultDto)
   }
 
   @Public()
   @Get()
-  findAll() {
+  findAll(@AuthenticatedUser() user: KeycloakTokenParsed) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+
     return this.vaultService.findAll()
   }
 
   @Public()
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@AuthenticatedUser() user: KeycloakTokenParsed,
+    @Param('id') id: string) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+
     return this.vaultService.findOne(id)
   }
 
   @Public()
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateVaultDto: UpdateVaultDto) {
+  update(@AuthenticatedUser() user: KeycloakTokenParsed,
+    @Param('id') id: string, @Body() updateVaultDto: UpdateVaultDto) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+
     return this.vaultService.update(id, updateVaultDto)
   }
 
   @Public()
   @Delete(':id')
-  remove(@Param('id') id: string) {
+  remove(@AuthenticatedUser() user: KeycloakTokenParsed,
+    @Param('id') id: string) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+
     return this.vaultService.remove(id)
+  }
+
+  @Post('/delete-many')
+  removeMany(
+    @AuthenticatedUser()
+    user: KeycloakTokenParsed,
+    @Body() idsToDelete: string[],
+  ) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+
+    return this.vaultService.removeMany(idsToDelete)
   }
 }

--- a/apps/api/src/vault/vault.controller.ts
+++ b/apps/api/src/vault/vault.controller.ts
@@ -1,34 +1,40 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
-import { VaultService } from './vault.service';
-import { CreateVaultDto } from './dto/create-vault.dto';
-import { UpdateVaultDto } from './dto/update-vault.dto';
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common'
+import { VaultService } from './vault.service'
+import { CreateVaultDto } from './dto/create-vault.dto'
+import { UpdateVaultDto } from './dto/update-vault.dto'
+import { Public } from 'nest-keycloak-connect'
 
 @Controller('vault')
 export class VaultController {
   constructor(private readonly vaultService: VaultService) {}
 
+  @Public()
   @Post()
   create(@Body() createVaultDto: CreateVaultDto) {
-    return this.vaultService.create(createVaultDto);
+    return this.vaultService.create(createVaultDto)
   }
 
+  @Public()
   @Get()
   findAll() {
-    return this.vaultService.findAll();
+    return this.vaultService.findAll()
   }
 
+  @Public()
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.vaultService.findOne(+id);
+    return this.vaultService.findOne(id)
   }
 
+  @Public()
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateVaultDto: UpdateVaultDto) {
-    return this.vaultService.update(+id, updateVaultDto);
+    return this.vaultService.update(id, updateVaultDto)
   }
 
+  @Public()
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return this.vaultService.remove(+id);
+    return this.vaultService.remove(id)
   }
 }

--- a/apps/api/src/vault/vault.controller.ts
+++ b/apps/api/src/vault/vault.controller.ts
@@ -9,7 +9,6 @@ import { KeycloakTokenParsed } from '../auth/keycloak'
 export class VaultController {
   constructor(private readonly vaultService: VaultService) { }
 
-  @Public()
   @Post()
   create(@AuthenticatedUser() user: KeycloakTokenParsed,
     @Body() createVaultDto: CreateVaultDto) {
@@ -20,7 +19,6 @@ export class VaultController {
     return this.vaultService.create(createVaultDto)
   }
 
-  @Public()
   @Get()
   findAll(@AuthenticatedUser() user: KeycloakTokenParsed) {
     if (!user) {
@@ -30,7 +28,6 @@ export class VaultController {
     return this.vaultService.findAll()
   }
 
-  @Public()
   @Get(':id')
   findOne(@AuthenticatedUser() user: KeycloakTokenParsed,
     @Param('id') id: string) {
@@ -41,7 +38,6 @@ export class VaultController {
     return this.vaultService.findOne(id)
   }
 
-  @Public()
   @Patch(':id')
   update(@AuthenticatedUser() user: KeycloakTokenParsed,
     @Param('id') id: string, @Body() updateVaultDto: UpdateVaultDto) {
@@ -52,7 +48,6 @@ export class VaultController {
     return this.vaultService.update(id, updateVaultDto)
   }
 
-  @Public()
   @Delete(':id')
   remove(@AuthenticatedUser() user: KeycloakTokenParsed,
     @Param('id') id: string) {

--- a/apps/api/src/vault/vault.controller.ts
+++ b/apps/api/src/vault/vault.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete, UnauthorizedException } from '@nestjs/common'
+import { AuthenticatedUser } from 'nest-keycloak-connect'
+
 import { VaultService } from './vault.service'
 import { CreateVaultDto } from './dto/create-vault.dto'
 import { UpdateVaultDto } from './dto/update-vault.dto'
-import { AuthenticatedUser, Public } from 'nest-keycloak-connect'
 import { KeycloakTokenParsed } from '../auth/keycloak'
 
 @Controller('vault')

--- a/apps/api/src/vault/vault.module.ts
+++ b/apps/api/src/vault/vault.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { VaultService } from './vault.service';
+import { VaultController } from './vault.controller';
+
+@Module({
+  controllers: [VaultController],
+  providers: [VaultService]
+})
+export class VaultModule {}

--- a/apps/api/src/vault/vault.module.ts
+++ b/apps/api/src/vault/vault.module.ts
@@ -1,9 +1,10 @@
-import { Module } from '@nestjs/common';
-import { VaultService } from './vault.service';
-import { VaultController } from './vault.controller';
+import { Module } from '@nestjs/common'
+import { VaultService } from './vault.service'
+import { VaultController } from './vault.controller'
+import { PrismaService } from '../prisma/prisma.service'
 
 @Module({
   controllers: [VaultController],
-  providers: [VaultService]
+  providers: [VaultService, PrismaService],
 })
 export class VaultModule {}

--- a/apps/api/src/vault/vault.module.ts
+++ b/apps/api/src/vault/vault.module.ts
@@ -3,9 +3,10 @@ import { Module } from '@nestjs/common'
 import { VaultService } from './vault.service'
 import { VaultController } from './vault.controller'
 import { PrismaService } from '../prisma/prisma.service'
+import { CampaignService } from '../campaign/campaign.service'
 
 @Module({
   controllers: [VaultController],
-  providers: [VaultService, PrismaService],
+  providers: [VaultService, CampaignService, PrismaService],
 })
 export class VaultModule { }

--- a/apps/api/src/vault/vault.module.ts
+++ b/apps/api/src/vault/vault.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+
 import { VaultService } from './vault.service'
 import { VaultController } from './vault.controller'
 import { PrismaService } from '../prisma/prisma.service'
@@ -7,4 +8,4 @@ import { PrismaService } from '../prisma/prisma.service'
   controllers: [VaultController],
   providers: [VaultService, PrismaService],
 })
-export class VaultModule {}
+export class VaultModule { }

--- a/apps/api/src/vault/vault.service.spec.ts
+++ b/apps/api/src/vault/vault.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VaultService } from './vault.service';
+
+describe('VaultService', () => {
+  let service: VaultService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [VaultService],
+    }).compile();
+
+    service = module.get<VaultService>(VaultService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/vault/vault.service.spec.ts
+++ b/apps/api/src/vault/vault.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { PrismaService } from '../prisma/prisma.service'
 import { VaultService } from './vault.service'
 
 describe('VaultService', () => {
@@ -6,7 +7,7 @@ describe('VaultService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VaultService],
+      providers: [VaultService, PrismaService],
     }).compile()
 
     service = module.get<VaultService>(VaultService)

--- a/apps/api/src/vault/vault.service.spec.ts
+++ b/apps/api/src/vault/vault.service.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { VaultService } from './vault.service';
+import { Test, TestingModule } from '@nestjs/testing'
+import { VaultService } from './vault.service'
 
 describe('VaultService', () => {
-  let service: VaultService;
+  let service: VaultService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [VaultService],
-    }).compile();
+    }).compile()
 
-    service = module.get<VaultService>(VaultService);
-  });
+    service = module.get<VaultService>(VaultService)
+  })
 
   it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-});
+    expect(service).toBeDefined()
+  })
+})

--- a/apps/api/src/vault/vault.service.spec.ts
+++ b/apps/api/src/vault/vault.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+
 import { PrismaService } from '../prisma/prisma.service'
 import { VaultService } from './vault.service'
 

--- a/apps/api/src/vault/vault.service.ts
+++ b/apps/api/src/vault/vault.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateVaultDto } from './dto/create-vault.dto';
+import { UpdateVaultDto } from './dto/update-vault.dto';
+
+@Injectable()
+export class VaultService {
+  create(createVaultDto: CreateVaultDto) {
+    return 'This action adds a new vault';
+  }
+
+  findAll() {
+    return `This action returns all vault`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} vault`;
+  }
+
+  update(id: number, updateVaultDto: UpdateVaultDto) {
+    return `This action updates a #${id} vault`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} vault`;
+  }
+}

--- a/apps/api/src/vault/vault.service.ts
+++ b/apps/api/src/vault/vault.service.ts
@@ -10,7 +10,7 @@ type DeleteManyResponse = {
 
 @Injectable()
 export class VaultService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private prisma: PrismaService) { }
 
   async create(createVaultDto: CreateVaultDto) {
     return await this.prisma.vault.create({ data: createVaultDto.toEntity() })
@@ -43,9 +43,7 @@ export class VaultService {
           id,
         },
         data: {
-          currency: updateVaultDto.currency,
-          amount: updateVaultDto.amount,
-          campaignId: updateVaultDto.campaignId,
+          name: updateVaultDto.name
         },
       })
     } catch (err) {

--- a/apps/api/src/vault/vault.service.ts
+++ b/apps/api/src/vault/vault.service.ts
@@ -30,10 +30,10 @@ export class VaultService {
         rejectOnNotFound: true,
       })
     } catch (err) {
-      const msg = `No Vault found with ID: ${id}`
+      const msg = `No Vault found with ID: ${id} Exception was: ${err.message}`
 
       Logger.warn(msg)
-      throw new NotFoundException(msg)
+      throw err
     }
   }
 
@@ -48,10 +48,10 @@ export class VaultService {
         },
       })
     } catch (err) {
-      const msg = `Update failed. No Vault found with ID: ${id}`
+      const msg = `Error while updating Vault with id: ${id}! Exception was: ${err.message}`
 
       Logger.warn(msg)
-      throw new NotFoundException(msg)
+      throw err
     }
   }
 

--- a/apps/api/src/vault/vault.service.ts
+++ b/apps/api/src/vault/vault.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { Vault } from '@prisma/client'
+
 import { PrismaService } from '../prisma/prisma.service'
 import { CreateVaultDto } from './dto/create-vault.dto'
 import { UpdateVaultDto } from './dto/update-vault.dto'

--- a/apps/api/src/vault/vault.service.ts
+++ b/apps/api/src/vault/vault.service.ts
@@ -63,10 +63,10 @@ export class VaultService {
         },
       })
     } catch (err) {
-      const msg = `Delete failed. No Vault found with ID: ${id}`
-
+      const msg = `Error while deleting Vault with id: ${id}! Exception was: ${err.message}`
       Logger.warn(msg)
-      throw new NotFoundException(msg)
+
+      throw err;
     }
   }
   async removeMany(idsToDelete: string[]): Promise<DeleteManyResponse> {
@@ -79,10 +79,10 @@ export class VaultService {
         },
       })
     } catch (err) {
-      const msg = `Delete failed. No Vault found with given ID`
-
+      const msg = `Error while deleting Vaults! Exception was: ${err.message}`
       Logger.warn(msg)
-      throw new NotFoundException(msg)
+
+      throw err;
     }
   }
 }

--- a/migrations/20220223105052_added_name_to_vault_model/migration.sql
+++ b/migrations/20220223105052_added_name_to_vault_model/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `name` to the `vaults` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "vaults" ADD COLUMN     "name" VARCHAR(100) NOT NULL;

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -201,6 +201,7 @@ Table Country {
 
 Table Vault {
   id String [pk]
+  name String [not null]
   currency Currency [not null, default: 'BGN']
   amount Int [not null, default: 0]
   campaignId String [not null]

--- a/schema.prisma
+++ b/schema.prisma
@@ -251,6 +251,7 @@ model Country {
 
 model Vault {
   id                 String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name               String              @db.VarChar(100)
   currency           Currency            @default(BGN)
   amount             Int                 @default(0) @db.Integer
   campaignId         String              @map("campaign_id") @db.Uuid
@@ -385,19 +386,19 @@ model BankAccount {
 
 /// Pay for something from a given vault
 model Expense {
-  id           String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id           String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   type         ExpenseType
-  status       ExpenseStatus 
-  currency     Currency    @default(BGN)
-  amount       Int         @default(0) @db.Integer
-  vaultId      String      @map("vault_id") @db.Uuid
-  deleted      Boolean     @default(false)
+  status       ExpenseStatus
+  currency     Currency      @default(BGN)
+  amount       Int           @default(0) @db.Integer
+  vaultId      String        @map("vault_id") @db.Uuid
+  deleted      Boolean       @default(false)
   description  String?
-  documentId   String?     @map("document_id") @db.Uuid
-  approvedById String?     @db.Uuid
-  vault        Vault       @relation(fields: [vaultId], references: [id]) 
-  approvedBy   Person?     @relation(fields: [approvedById], references: [id])
-  document     Document?   @relation(fields: [documentId], references: [id])
+  documentId   String?       @map("document_id") @db.Uuid
+  approvedById String?       @db.Uuid
+  vault        Vault         @relation(fields: [vaultId], references: [id])
+  approvedBy   Person?       @relation(fields: [approvedById], references: [id])
+  document     Document?     @relation(fields: [documentId], references: [id])
 
   @@map("expenses")
 }


### PR DESCRIPTION
Closing [#107 ](https://github.com/podkrepi-bg/api/issues/107)

providing the following crud functionality:

- create
- edit by id
- delete by id
- delete many
- read list
 -read by id

added a name field to the prisma schema
a couple conflicts occurred in the campaign service and createDto due to the changes in the Vault model
I have added a temporary example name to dismiss the errors

I have also added name field to the vault seed through faker

through updateDto only name can be updated

I am not sure yet how to deal with the other relations of the model
I am open to suggestions to improve this pull request :)