### PR TITLE
Remove assignment of anonymous name

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -142,11 +142,6 @@ export class CampaignService {
       },
     })
 
-    donations.map((donation) => {
-      if (!donation.person)
-        donation.person = { firstName: 'anonymous', lastName: '' }
-    })
-
     return donations
   }
 


### PR DESCRIPTION
The _Person_ object should remain null, if the donation is anonymous.

solve [this issue](https://github.com/podkrepi-bg/api/issues/67)