### PR TITLE
Endpoint for admins to add donations from bank payments

### DIFF
--- a/apps/api/src/donations/donations.controller.ts
+++ b/apps/api/src/donations/donations.controller.ts
@@ -7,6 +7,7 @@ import { DonationsService } from './donations.service'
 import { CreateSessionDto } from './dto/create-session.dto'
 import { CreatePaymentDto } from './dto/create-payment.dto'
 import { UpdatePaymentDto } from './dto/update-payment.dto'
+import { CreateBankPaymentDto } from './dto/create-bank-payment.dto'
 
 @Controller('donation')
 export class DonationsController {
@@ -65,6 +66,23 @@ export class DonationsController {
     }
 
     return this.donationsService.create(createPaymentDto, user)
+  }
+
+  @Post('create-bank-payment')
+  @Roles({
+    roles: [RealmViewSupporters.role, ViewSupporters.role],
+    mode: RoleMatchingMode.ANY,
+  })
+  createBankPayment(
+    @AuthenticatedUser()
+    user: KeycloakTokenParsed,
+    bankPaymentDto: CreateBankPaymentDto,
+  ) {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
+
+    return this.donationsService.createBankPayment(bankPaymentDto)
   }
 
   @Patch(':id')

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -11,6 +11,7 @@ import { CreatePaymentDto } from './dto/create-payment.dto'
 import { UpdatePaymentDto } from './dto/update-payment.dto'
 import { CampaignService } from '../campaign/campaign.service'
 import { DonationMetadata } from './dontation-metadata.interface'
+import { CreateBankPaymentDto } from './dto/create-bank-payment.dto'
 
 type DeleteManyResponse = {
   count: number
@@ -85,6 +86,10 @@ export class DonationsService {
 
   async create(inputDto: CreatePaymentDto, user: KeycloakTokenParsed): Promise<Donation> {
     return await this.prisma.donation.create({ data: inputDto.toEntity(user) })
+  }
+
+  async createBankPayment(inputDto: CreateBankPaymentDto): Promise<Donation> {
+    return await this.prisma.donation.create({ data: inputDto.toEntity() })
   }
 
   async update(id: string, updatePaymentDto: UpdatePaymentDto): Promise<Donation> {

--- a/apps/api/src/donations/dto/create-bank-payment.dto.ts
+++ b/apps/api/src/donations/dto/create-bank-payment.dto.ts
@@ -1,0 +1,93 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Currency, DonationStatus, DonationType, PaymentProvider, Prisma } from '@prisma/client'
+import { Expose } from 'class-transformer'
+import { IsEmail, IsNumber, IsOptional, IsPositive, IsString, IsUUID } from 'class-validator'
+
+@Expose()
+export class CreateBankPaymentDto {
+  @Expose()
+  @ApiProperty({ enum: Currency })
+  currency: Currency
+
+  @Expose()
+  @ApiProperty()
+  @IsNumber()
+  @IsPositive()
+  amount: number
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  extCustomerId: string
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  extPaymentIntentId: string
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  extPaymentMethodId: string
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsUUID()
+  targetVaultId: string
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  personsFirstName: string | null
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  personsLastName: string | null
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  @IsEmail()
+  @IsUUID()
+  personsEmail: string | null
+
+  public toEntity(): Prisma.DonationCreateInput {
+    const donation: Prisma.DonationCreateInput = {
+      type: DonationType.donation,
+      status: DonationStatus.succeeded,
+      provider: PaymentProvider.bank,
+      currency: this.currency,
+      amount: this.amount,
+      extCustomerId: this.extCustomerId,
+      extPaymentIntentId: this.extPaymentIntentId,
+      extPaymentMethodId: this.extPaymentMethodId,
+      targetVault: {
+        connect: {
+          id: this.targetVaultId,
+        },
+      },
+    }
+
+    if (this.personsEmail && this.personsFirstName && this.personsLastName) {
+      donation.person = {
+        connectOrCreate: {
+          where: {
+            email: this.personsEmail,
+          },
+          create: {
+            firstName: this.personsFirstName,
+            lastName: this.personsLastName,
+            email: this.personsEmail,
+          },
+        },
+      }
+    }
+
+    return donation
+  }
+}


### PR DESCRIPTION
Added endpoint enabling the admins to add donations which were transferred by bank payments.

Note: If person's First name, Last name and Email is NOT specified, the donation is going to be anonymous.