### PR TITLE
Refresh token endpoint

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -7,12 +7,15 @@ import { PrismaService } from '../prisma/prisma.service'
 import { RegisterController } from './register.controller'
 import { AppConfigModule } from '../config/app-config.module'
 import { KeycloakConfigService } from '../config/keycloak-config.service'
+import { RefreshController } from './refresh.controller';
+import { HttpModule } from '@nestjs/axios'
 
 @Module({
-  controllers: [LoginController, RegisterController],
+  controllers: [LoginController, RegisterController, RefreshController],
   providers: [AuthService, PrismaService],
   imports: [
     AppConfigModule,
+    HttpModule,
     KeycloakConnectModule.registerAsync({
       useExisting: KeycloakConfigService,
       imports: [AppConfigModule],

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -13,6 +13,7 @@ import { LoginDto } from './dto/login.dto'
 import { AuthService } from './auth.service'
 import { RegisterDto } from './dto/register.dto'
 import { MockPrismaService, prismaMock } from '../prisma/prisma-client.mock'
+import { RefreshDto } from './dto/refresh.dto'
 
 jest.mock('@keycloak/keycloak-admin-client')
 
@@ -80,6 +81,18 @@ describe('AuthService', () => {
       expect(await service.issueToken(email, password)).toBe('t23456')
       expect(keycloakSpy).toHaveBeenCalledWith(email, password)
       expect(tokenSpy).toHaveBeenCalledWith(email, password)
+      expect(admin.auth).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('refresh', () => {
+    it('should call issueTokenFromRefresh', async () => {
+      const refreshToken = 'JWT_TOKEN'
+      const refreshDto = plainToClass(RefreshDto, { refreshToken })
+      const refreshSpy = jest.spyOn(service, 'issueTokenFromRefresh')
+
+      expect(await service.issueTokenFromRefresh(refreshDto)).toBeObject()
+      expect(refreshSpy).toHaveBeenCalledWith(refreshDto)
       expect(admin.auth).not.toHaveBeenCalled()
     })
   })

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -14,6 +14,8 @@ import { AuthService } from './auth.service'
 import { RegisterDto } from './dto/register.dto'
 import { MockPrismaService, prismaMock } from '../prisma/prisma-client.mock'
 import { RefreshDto } from './dto/refresh.dto'
+import { Observable } from 'rxjs'
+import { TokenResponseRaw } from '@keycloak/keycloak-admin-client/lib/utils/auth'
 
 jest.mock('@keycloak/keycloak-admin-client')
 
@@ -77,7 +79,6 @@ describe('AuthService', () => {
       const keycloakSpy = jest
         .spyOn(keycloak.grantManager, 'obtainDirectly')
         .mockResolvedValue(token)
-
       expect(await service.issueToken(email, password)).toBe('t23456')
       expect(keycloakSpy).toHaveBeenCalledWith(email, password)
       expect(tokenSpy).toHaveBeenCalledWith(email, password)
@@ -89,7 +90,9 @@ describe('AuthService', () => {
     it('should call issueTokenFromRefresh', async () => {
       const refreshToken = 'JWT_TOKEN'
       const refreshDto = plainToClass(RefreshDto, { refreshToken })
-      const refreshSpy = jest.spyOn(service, 'issueTokenFromRefresh')
+      const refreshSpy = jest.spyOn(service, 'issueTokenFromRefresh').mockResolvedValue(new Observable((s => {
+        s.next({} as TokenResponseRaw)
+      })))
 
       expect(await service.issueTokenFromRefresh(refreshDto)).toBeObject()
       expect(refreshSpy).toHaveBeenCalledWith(refreshDto)

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,6 +1,7 @@
 import { Person } from '.prisma/client'
 import { mockDeep } from 'jest-mock-extended'
 import { ConfigService } from '@nestjs/config'
+import { HttpService } from '@nestjs/axios'
 import { plainToClass } from 'class-transformer'
 import { Test, TestingModule } from '@nestjs/testing'
 import { UnauthorizedException } from '@nestjs/common'
@@ -19,6 +20,7 @@ describe('AuthService', () => {
   let service: AuthService
   let config: ConfigService
   let admin: KeycloakAdminClient
+  let httpService: HttpService
   let keycloak: KeycloakConnect.Keycloak
 
   beforeEach(async () => {
@@ -39,6 +41,10 @@ describe('AuthService', () => {
           provide: KeycloakAdminClient,
           useValue: mockDeep<KeycloakAdminClient>(),
         },
+        {
+          provide: HttpService,
+          useValue: mockDeep<HttpService>(),
+        },
         MockPrismaService,
         {
           provide: KEYCLOAK_INSTANCE,
@@ -51,6 +57,7 @@ describe('AuthService', () => {
     config = module.get<ConfigService>(ConfigService)
     admin = module.get<KeycloakAdminClient>(KeycloakAdminClient)
     keycloak = module.get<KeycloakConnect.Keycloak>(KEYCLOAK_INSTANCE)
+    httpService = module.get<HttpService>(HttpService)
   })
 
   it('should be defined', () => {

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -8,6 +8,7 @@ import { UnauthorizedException } from '@nestjs/common'
 import KeycloakConnect, { Grant } from 'keycloak-connect'
 import { KEYCLOAK_INSTANCE } from 'nest-keycloak-connect'
 import KeycloakAdminClient from '@keycloak/keycloak-admin-client'
+import { TokenResponseRaw } from '@keycloak/keycloak-admin-client/lib/utils/auth'
 
 import { LoginDto } from './dto/login.dto'
 import { AuthService } from './auth.service'
@@ -15,7 +16,6 @@ import { RegisterDto } from './dto/register.dto'
 import { MockPrismaService, prismaMock } from '../prisma/prisma-client.mock'
 import { RefreshDto } from './dto/refresh.dto'
 import { Observable } from 'rxjs'
-import { TokenResponseRaw } from '@keycloak/keycloak-admin-client/lib/utils/auth'
 
 jest.mock('@keycloak/keycloak-admin-client')
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -66,10 +66,10 @@ export class AuthService {
     const clientId = this.config.get<string>('keycloak.clientId')
     const tokenUrl = `${this.config.get<string>('keycloak.serverUrl')}/realms/${this.config.get<string>('keycloak.realm')}/protocol/openid-connect/token`
     const data = {
-      'client_id':clientId as string,
-      'client_secret':secret as string,
-      'refresh_token': refreshDto.refreshToken,
-      'grant_type':'refresh_token'
+      client_id: clientId as string,
+      client_secret: secret as string,
+      refresh_token: refreshDto.refreshToken,
+      grant_type: <const>'refresh_token'
     }
     const params = new URLSearchParams(data)
     return this.httpService.post<KeycloakErrorResponse | TokenResponseRaw>(tokenUrl,params.toString()).pipe(

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -19,20 +19,10 @@ import { HttpService } from '@nestjs/axios'
 import { RefreshDto } from './dto/refresh.dto'
 import { catchError, map } from 'rxjs'
 import { AxiosResponse } from '@nestjs/terminus/dist/health-indicator/http/axios.interfaces'
+import { TokenResponseRaw } from '@keycloak/keycloak-admin-client/lib/utils/auth'
 
 type ErrorResponse = { error: string; data: unknown }
 type KeycloakErrorResponse = { error: string; 'error_description': string }
-type TokenResponse = { 
-  "access_token": string,
-  "expires_in": number,
-  "refresh_expires_in": number,
-  "refresh_token": string,
-  "token_type": string,
-  "id_token": string,
-  "not-before-policy": number,
-  "session_state": string,
-  "scope": string
- }
 type LoginResponse = {
   user: KeycloakTokenParsed | undefined
   accessToken: string | undefined
@@ -82,7 +72,7 @@ export class AuthService {
       'grant_type':'refresh_token'
     }
     const params = new URLSearchParams(data)
-    return this.httpService.post<KeycloakErrorResponse | TokenResponse>(tokenUrl,params.toString()).pipe(
+    return this.httpService.post<KeycloakErrorResponse | TokenResponseRaw>(tokenUrl,params.toString()).pipe(
       map(res => res.data),
       catchError(({response} :{response: AxiosResponse<KeycloakErrorResponse>}) => {
       const error = response.data;

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -4,22 +4,22 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common'
+import { HttpService } from '@nestjs/axios'
+import { catchError, map } from 'rxjs'
 import KeycloakConnect from 'keycloak-connect'
 import { ConfigService } from '@nestjs/config'
 import { KEYCLOAK_INSTANCE } from 'nest-keycloak-connect'
 import KeycloakAdminClient from '@keycloak/keycloak-admin-client'
 import { RequiredActionAlias } from '@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderRepresentation'
-
-import { Person } from '.prisma/client'
-import { LoginDto } from './dto/login.dto'
-import { RegisterDto } from './dto/register.dto'
-import { KeycloakTokenParsed } from './keycloak'
-import { PrismaService } from '../prisma/prisma.service'
-import { HttpService } from '@nestjs/axios'
-import { RefreshDto } from './dto/refresh.dto'
-import { catchError, map } from 'rxjs'
 import { AxiosResponse } from '@nestjs/terminus/dist/health-indicator/http/axios.interfaces'
 import { TokenResponseRaw } from '@keycloak/keycloak-admin-client/lib/utils/auth'
+
+import { Person } from '.prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { LoginDto } from './dto/login.dto'
+import { RegisterDto } from './dto/register.dto'
+import { RefreshDto } from './dto/refresh.dto'
+import { KeycloakTokenParsed } from './keycloak'
 
 type ErrorResponse = { error: string; data: unknown }
 type KeycloakErrorResponse = { error: string; 'error_description': string }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -78,7 +78,7 @@ export class AuthService {
     const data = {
       'client_id':clientId as string,
       'client_secret':secret as string,
-      'refresh_token': refreshDto.refreshToken as string,
+      'refresh_token': refreshDto.refreshToken,
       'grant_type':'refresh_token'
     }
     const params = new URLSearchParams(data)

--- a/apps/api/src/auth/dto/refresh.dto.ts
+++ b/apps/api/src/auth/dto/refresh.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Expose } from 'class-transformer'
+import { IsNotEmpty, IsString } from 'class-validator'
+
+export class RefreshDto {
+  @ApiProperty()
+  @Expose()
+  @IsNotEmpty()
+  @IsString()
+  public readonly refreshToken: string
+}

--- a/apps/api/src/auth/dto/refresh.dto.ts
+++ b/apps/api/src/auth/dto/refresh.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose } from 'class-transformer'
-import { IsNotEmpty, IsString } from 'class-validator'
+import { IsJWT, IsNotEmpty, IsString } from 'class-validator'
 
 export class RefreshDto {
   @ApiProperty()
   @Expose()
   @IsNotEmpty()
   @IsString()
+  @IsJWT()
   public readonly refreshToken: string
 }

--- a/apps/api/src/auth/refresh.controller.spec.ts
+++ b/apps/api/src/auth/refresh.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RefreshController } from './refresh.controller';
+
+describe('RefreshController', () => {
+  let controller: RefreshController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RefreshController],
+    }).compile();
+
+    controller = module.get<RefreshController>(RefreshController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/auth/refresh.controller.spec.ts
+++ b/apps/api/src/auth/refresh.controller.spec.ts
@@ -1,18 +1,39 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+import { RefreshDto } from './dto/refresh.dto';
 import { RefreshController } from './refresh.controller';
 
 describe('RefreshController', () => {
-  let controller: RefreshController;
+  let controller: RefreshController
+  let spyService: AuthService
 
   beforeEach(async () => {
+    const AuthServiceProvider = {
+      provide: AuthService,
+      useFactory: () => ({
+        issueTokenFromRefresh: jest.fn(() => ({})),
+      }),
+    }
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RefreshController],
-    }).compile();
+      providers: [AuthService, AuthServiceProvider],
+    }).compile()
 
-    controller = module.get<RefreshController>(RefreshController);
-  });
+    controller = module.get<RefreshController>(RefreshController)
+    spyService = module.get<AuthService>(AuthService)
+  })
 
   it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-});
+    expect(controller).toBeDefined()
+  })
+
+  describe('refreshToken', () => {
+    const refreshDto = new RefreshDto()
+    it('should call refreshToken', async () => {
+      expect(await controller.refresh(refreshDto))
+      expect(spyService.issueTokenFromRefresh).toHaveBeenCalled()
+      expect(spyService.issueTokenFromRefresh).toHaveBeenCalledWith(refreshDto)
+    })
+  })
+})

--- a/apps/api/src/auth/refresh.controller.ts
+++ b/apps/api/src/auth/refresh.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { Public, Resource } from 'nest-keycloak-connect';
+import { AuthService } from './auth.service';
+import { RefreshDto } from './dto/refresh.dto';
+
+@Controller('refresh')
+@Resource('refresh')
+export class RefreshController {
+    constructor(private readonly authService: AuthService) {}
+    @Post()
+    @Public()
+    async refresh(@Body() refreshDto: RefreshDto) {
+      return await this.authService.issueTokenFromRefresh(refreshDto)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@golevelup/nestjs-stripe": "0.3.3",
     "@golevelup/nestjs-webhooks": "0.2.12",
     "@keycloak/keycloak-admin-client": "18.0.0",
+    "@nestjs/axios": "^0.0.7",
     "@nestjs/cli": "8.2.5",
     "@nestjs/common": "8.4.5",
     "@nestjs/config": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,6 +790,13 @@
     url-join "^4.0.0"
     url-template "^2.0.8"
 
+"@nestjs/axios@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-0.0.7.tgz#7f134636db13c2c1e8299365c7eceb73cd782b67"
+  integrity sha512-at8nj+1Nb8UleHcIN5QqZYeWX54m4m9s9gxzVE1qWy00neX2rg0+h2TfbWsnDi2tc23zIxqexanxMOJZbzO0CA==
+  dependencies:
+    axios "0.26.0"
+
 "@nestjs/cli@8.2.5":
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-8.2.5.tgz#02094177f4eac576d1a559b259d541393e49e0bb"
@@ -2509,6 +2516,13 @@ aws-sdk@2.1135.0:
     url "0.10.3"
     uuid "3.3.2"
     xml2js "0.4.19"
+
+axios@0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
+  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 axios@0.27.2:
   version "0.27.2"
@@ -6012,12 +6026,7 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
-
-minimist@^1.2.6:
+minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
Related to #168, but I can't quite understand the issue!

Added an endpoint for fetching an `access_token` when you give a `refresh_token`.
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/61479393/168544105-5f7721a5-0976-4aaa-882a-a830e39ce87f.png">

I needed to use a normal http request since the Keycloak SDK does not support that request or at least I couldn't find it.
Because of that I needed to add `@nestjs/axios` to the dependencies