### PR TITLE
Auth token response change

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -90,9 +90,15 @@ describe('AuthService', () => {
     it('should call issueTokenFromRefresh', async () => {
       const refreshToken = 'JWT_TOKEN'
       const refreshDto = plainToClass(RefreshDto, { refreshToken })
-      const refreshSpy = jest.spyOn(service, 'issueTokenFromRefresh').mockResolvedValue(new Observable((s => {
-        s.next({} as TokenResponseRaw)
-      })))
+      const refreshSpy = jest.spyOn(service, 'issueTokenFromRefresh').mockResolvedValue(
+        new Observable((s) => {
+          s.next({
+            accessToken: 'test',
+            refreshToken: 'test-refresh',
+            expires: '300',
+          })
+        }),
+      )
 
       expect(await service.issueTokenFromRefresh(refreshDto)).toBeObject()
       expect(refreshSpy).toHaveBeenCalledWith(refreshDto)

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -59,7 +59,9 @@ export class AuthService {
     return grant.access_token?.token
   }
 
-  async issueTokenFromRefresh(refreshDto: RefreshDto): Promise<Observable<ApiTokenResponse>> {
+  async issueTokenFromRefresh(
+    refreshDto: RefreshDto,
+  ): Promise<Observable<ApiTokenResponse | ErrorResponse>> {
     const secret = this.config.get<string>('keycloak.secret')
     const clientId = this.config.get<string>('keycloak.clientId')
     const tokenUrl = `${this.config.get<string>(

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -5,7 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common'
 import { HttpService } from '@nestjs/axios'
-import { catchError, map } from 'rxjs'
+import { catchError, map, Observable } from 'rxjs'
 import KeycloakConnect from 'keycloak-connect'
 import { ConfigService } from '@nestjs/config'
 import { KEYCLOAK_INSTANCE } from 'nest-keycloak-connect'
@@ -22,9 +22,9 @@ import { RefreshDto } from './dto/refresh.dto'
 import { KeycloakTokenParsed } from './keycloak'
 
 type ErrorResponse = { error: string; data: unknown }
-type KeycloakErrorResponse = { error: string; 'error_description': string }
-type LoginResponse = {
-  user: KeycloakTokenParsed | undefined
+type KeycloakErrorResponse = { error: string; error_description: string }
+type ApiTokenResponse = {
+  expires: string | undefined
   accessToken: string | undefined
   refreshToken: string | undefined
 }
@@ -39,8 +39,6 @@ declare module 'keycloak-connect' {
     content: KeycloakTokenParsed | undefined
   }
 }
-
-
 
 @Injectable()
 export class AuthService {
@@ -61,38 +59,47 @@ export class AuthService {
     return grant.access_token?.token
   }
 
-  async issueTokenFromRefresh(refreshDto: RefreshDto) {
+  async issueTokenFromRefresh(refreshDto: RefreshDto): Promise<Observable<ApiTokenResponse>> {
     const secret = this.config.get<string>('keycloak.secret')
     const clientId = this.config.get<string>('keycloak.clientId')
-    const tokenUrl = `${this.config.get<string>('keycloak.serverUrl')}/realms/${this.config.get<string>('keycloak.realm')}/protocol/openid-connect/token`
+    const tokenUrl = `${this.config.get<string>(
+      'keycloak.serverUrl',
+    )}/realms/${this.config.get<string>('keycloak.realm')}/protocol/openid-connect/token`
     const data = {
       client_id: clientId as string,
       client_secret: secret as string,
       refresh_token: refreshDto.refreshToken,
-      grant_type: <const>'refresh_token'
+      grant_type: <const>'refresh_token',
     }
     const params = new URLSearchParams(data)
-    return this.httpService.post<KeycloakErrorResponse | TokenResponseRaw>(tokenUrl,params.toString()).pipe(
-      map(res => res.data),
-      catchError(({response} :{response: AxiosResponse<KeycloakErrorResponse>}) => {
-      const error = response.data;
-      if (error.error === 'invalid_grant') {
-        throw new UnauthorizedException(error['error_description'])
-      }
-      throw new InternalServerErrorException('CannotIssueTokenError')
-    }))
+    return this.httpService
+      .post<KeycloakErrorResponse | TokenResponseRaw>(tokenUrl, params.toString())
+      .pipe(
+        map((res: AxiosResponse<TokenResponseRaw>) => ({
+          refreshToken: res.data.refresh_token,
+          accessToken: res.data.access_token,
+          expires: res.data.expires_in,
+        })),
+        catchError(({ response }: { response: AxiosResponse<KeycloakErrorResponse> }) => {
+          const error = response.data
+          if (error.error === 'invalid_grant') {
+            throw new UnauthorizedException(error['error_description'])
+          }
+          throw new InternalServerErrorException('CannotIssueTokenError')
+        }),
+      )
   }
 
-  async login(loginDto: LoginDto): Promise<LoginResponse | ErrorResponse> {
+  async login(loginDto: LoginDto): Promise<ApiTokenResponse | ErrorResponse> {
     try {
       const grant = await this.issueGrant(loginDto.email, loginDto.password)
       if (!grant.access_token?.token) {
         throw new InternalServerErrorException('CannotIssueTokenError')
       }
       return {
-        user: grant.access_token?.content,
-        accessToken: grant.access_token?.token,
         refreshToken: grant.refresh_token?.token,
+        accessToken: grant.access_token.token,
+        expires: grant.expires_in,
       }
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
Change it so the API now only sends an `AuthResponse` object including only 
`{ accessToken: string,
 refreshToken: string,
 expires: number }`
And then the frontend is responsible for parsing the `accessToken` and taking the user information out of it.

It is connected to the #779(https://github.com/podkrepi-bg/frontend/pull/779). PR on the frontend