### PR TITLE
Upgrade local-keycloak image to v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ yarn
 :information_source: Use `docker-compose` version `>=2.5`
 
 ```shell
-docker-compose --profile local-keycloak up -d
+docker-compose --profile local-keycloak up -d --build
 ```
 
 This will start the following services in your local docker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
   #####################
   keycloak:
     container_name: ${COMPOSE_PROJECT_NAME?}-keycloak
-    image: docker.io/bitnami/keycloak:15
+    image: docker.io/bitnami/keycloak:18
     profiles: ['local-keycloak']
     environment:
       - KEYCLOAK_USER=${KEYCLOAK_PASSWORD}


### PR DESCRIPTION
Motivation: frontend already expects keycloak to be v18

