### PR TITLE
Campaign creation improvements

### DIFF
--- a/apps/api/src/campaign/campaign.controller.spec.ts
+++ b/apps/api/src/campaign/campaign.controller.spec.ts
@@ -58,7 +58,7 @@ describe('CampaignController', () => {
     ...mockCreateCampaign,
     ...{
       id: 'testId',
-      state: CampaignState.active,
+      state: CampaignState.draft,
       createdAt: new Date('2022-04-08T06:36:33.661Z'),
       updatedAt: new Date('2022-04-08T06:36:33.662Z'),
       deletedAt: null,
@@ -115,7 +115,7 @@ describe('CampaignController', () => {
         ...mockCreateCampaign,
         ...{
           id: 'testId',
-          state: CampaignState.active,
+          state: CampaignState.draft,
           createdAt: new Date('2022-04-08T06:36:33.661Z'),
           updatedAt: new Date('2022-04-08T06:36:33.662Z'),
           deletedAt: null,

--- a/apps/api/src/campaign/campaign.controller.ts
+++ b/apps/api/src/campaign/campaign.controller.ts
@@ -1,4 +1,4 @@
-import { Campaign } from '.prisma/client'
+import { Campaign, CampaignState } from '.prisma/client'
 import { AuthenticatedUser, Public, RoleMatchingMode, Roles } from 'nest-keycloak-connect'
 import { RealmViewSupporters, ViewSupporters } from '@podkrepi-bg/podkrepi-types'
 import {
@@ -13,6 +13,7 @@ import {
   forwardRef,
   Inject,
   Logger,
+  BadRequestException,
 } from '@nestjs/common'
 
 import { CampaignService } from './campaign.service'
@@ -54,6 +55,14 @@ export class CampaignController {
     @Body() createDto: CreateCampaignDto,
     @AuthenticatedUser() user: KeycloakTokenParsed,
   ) {
+    if (createDto.state != CampaignState.draft) {
+      const message =
+        "Can't create campaign in state different than draft. Not allowed state value received: " +
+        createDto.state
+      Logger.error(message)
+      throw new BadRequestException(message)
+    }
+
     if (!isAdmin(user)) {
       Logger.warn('The campaign creator is not in admin role. User name is: ' + user.name)
     }

--- a/apps/api/src/campaign/campaign.controller.ts
+++ b/apps/api/src/campaign/campaign.controller.ts
@@ -55,7 +55,7 @@ export class CampaignController {
     @Body() createDto: CreateCampaignDto,
     @AuthenticatedUser() user: KeycloakTokenParsed,
   ) {
-    if (createDto.state != CampaignState.draft) {
+    if (createDto.state && createDto.state != CampaignState.draft) {
       const message =
         "Can't create campaign in state different than draft. Not allowed state value received: " +
         createDto.state

--- a/apps/api/src/campaign/dto/create-campaign.dto.ts
+++ b/apps/api/src/campaign/dto/create-campaign.dto.ts
@@ -12,7 +12,7 @@ import {
 } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose, Type } from 'class-transformer'
-import { Currency, Prisma } from '.prisma/client'
+import { CampaignState, Currency, Prisma } from '.prisma/client'
 import { getPaymentReference } from '../helpers/payment-reference'
 
 @Expose()
@@ -98,6 +98,13 @@ export class CreateCampaignDto {
   @Type(() => Date)
   endDate: Date | null
 
+  @ApiProperty()
+  @Expose()
+  @IsOptional()
+  @IsString()
+  @IsEnum(CampaignState)
+  state: CampaignState | undefined
+
   public toEntity(): Prisma.CampaignCreateInput {
     return {
       title: this.title,
@@ -110,6 +117,7 @@ export class CreateCampaignDto {
       allowDonationOnComplete: this.allowDonationOnComplete,
       startDate: this.startDate,
       endDate: this.endDate,
+      state: this.state,
       vaults: { create: { currency: this.currency, name: this.title } },
       campaignType: { connect: { id: this.campaignTypeId } },
       beneficiary: { connect: { id: this.beneficiaryId } },

--- a/db/seed/campaign.seed.ts
+++ b/db/seed/campaign.seed.ts
@@ -21,7 +21,9 @@ export async function campaignSeed() {
     throw new Error('No coordinator')
   }
 
-  const beneficiaryFromDb = await prisma.beneficiary.findFirst()
+  const beneficiaryFromDb = await prisma.beneficiary.findFirst({
+    where: { person: { email: 'receiver@podkrepi.bg' } },
+  })
   console.log(beneficiaryFromDb)
 
   if (!beneficiaryFromDb) {
@@ -36,18 +38,18 @@ export async function campaignSeed() {
   }
 
   const insert = await prisma.campaign.createMany({
-    data: [...Array(20).keys()].map(() => {
-      const title = faker.lorem.sentence()
+    data: [...Array(12).keys()].map(() => {
+      const title = faker.lorem.sentence(3)
       const randomType = campaignTypeFromDb[Math.floor(Math.random() * campaignTypeFromDb.length)]
       return {
-        state: CampaignState.active,
+        state: faker.random.objectElement<CampaignState>(CampaignState),
         slug: faker.helpers.slugify(title).replace('.', '').toLowerCase(),
         title,
         essence: faker.company.catchPhrase(),
         coordinatorId: coordinatorFromDb.id,
         beneficiaryId: beneficiaryFromDb.id,
         campaignTypeId: randomType.id,
-        description: faker.lorem.paragraphs(4),
+        description: faker.lorem.paragraphs(1),
         targetAmount: parseInt(faker.finance.amount(2000, 200000)),
         currency: Currency.BGN,
         paymentReference: getPaymentReference(),


### PR DESCRIPTION
## Motivation and context
Trying to polish the campaign creation and fixing small things all over 

- corrected the comment in migration - it is safe to execute on existing data
- list campaigns now returns soonest campaign by endDate on top
- added logging for campaign creation
- replaced short-unique-id with nanoid as it was already in golevelup/nestjs-stripe
- renamed bankHash to paymentReference to better illustrate what it is needed for
- extended the paymentReference code from 5 to 12 symbols and added dashes to make it friendlier. Codes look like this now: "NY5P-KVO4-DNBZ" and guarantee 35years until 1% probability of duplicate
- paymentReference is now unique per campaign in database schema 
- all authenticated users should be able to create campaigns in draft mode. 
- added: campaign.state in campaign request so that it can be changed in frontend
