### PR TITLE
fixed: irregularity files can be downloaded only from admin users

### DIFF
--- a/apps/api/src/irregularity-file/irregularity-file.controller.ts
+++ b/apps/api/src/irregularity-file/irregularity-file.controller.ts
@@ -69,13 +69,10 @@ export class IrregularityFileController {
   }
 
   @Get(':id')
-  @Public()
-  // TODO: need to fix frontend to pass credentials for getting the file
-  // see issue: https://github.com/podkrepi-bg/frontend/issues/811
-  // @Roles({
-  //   roles: [RealmViewContactRequests.role, ViewContactRequests.role],
-  //   mode: RoleMatchingMode.ANY,
-  // })
+  @Roles({
+    roles: [RealmViewContactRequests.role, ViewContactRequests.role],
+    mode: RoleMatchingMode.ANY,
+  })
   async findOne(
     @Param('id') id: string,
     @Response({ passthrough: true }) res,


### PR DESCRIPTION
Fixed: irregularity files can be downloaded only from admin users
The file is properly requested with credentials in frontend master as of rev. #16dd10feb836ab773ca1df14a7f5df4826ac1cc1

