### PR TITLE
fixing admin create beneficiery issue 818

### DIFF
--- a/apps/api/src/beneficiary/beneficiary.controller.spec.ts
+++ b/apps/api/src/beneficiary/beneficiary.controller.spec.ts
@@ -23,12 +23,13 @@ const mockData = [
     description: '',
     privateData: '',
     publicData: '',
-    companyId: null,
+    companyId: '',
   },
   {
+    //company
     id: '159c3d7b-f752-43e9-870b-f05e5b7c313c',
-    type: BeneficiaryType.individual,
-    personId: 'e08d9539-f830-456f-9510-a0f3ef6f93ec',
+    type: BeneficiaryType.company,
+    personId: '',
     coordinatorId: 'da2980b0-86ea-41bd-a7f9-78c49da04e32',
     countryCode: 'BG',
     cityId: 'a7ba19e5-c23b-40d6-bcb0-cf2f4acfb0f5',
@@ -38,7 +39,7 @@ const mockData = [
     description: '',
     privateData: '',
     publicData: '',
-    companyId: null,
+    companyId: 'e08d9539-f830-456f-9510-a0f3ef6f93ec',
   },
   {
     id: '160e2ec4-d012-432b-b439-22402a074085',
@@ -53,7 +54,7 @@ const mockData = [
     description: '',
     privateData: '',
     publicData: '',
-    companyId: null,
+    companyId: '',
   },
 ]
 
@@ -117,6 +118,7 @@ describe('BeneficiaryController', () => {
     const createDto: CreateBeneficiaryDto = {
       type: BeneficiaryType.individual,
       personId: beneficiary.personId,
+      companyId: '',
       coordinatorId: beneficiary.coordinatorId,
       countryCode: beneficiary.countryCode,
       cityId: beneficiary.cityId,
@@ -133,6 +135,7 @@ describe('BeneficiaryController', () => {
 
   it('it should update beneficiary', async () => {
     const beneficiary = mockData[0]
+    beneficiary.description = 'Updated Description'
     prismaMock.beneficiary.update.mockResolvedValue(beneficiary)
 
     const result = await controller.editById(beneficiary.id, beneficiary)
@@ -142,6 +145,7 @@ describe('BeneficiaryController', () => {
       data: beneficiary,
     })
   })
+
   it('should remove one item', async () => {
     const beneficiary = mockData[0]
     prismaMock.beneficiary.delete.mockResolvedValue(beneficiary)
@@ -149,5 +153,17 @@ describe('BeneficiaryController', () => {
     const result = await controller.deleteById(beneficiary.id)
     expect(result).toEqual(beneficiary)
     expect(prismaMock.beneficiary.delete).toHaveBeenCalledWith({ where: { id: beneficiary.id } })
+  })
+
+  it('it should create beneficiary as company', async () => {
+    const beneficiary = mockData[1]
+    prismaMock.beneficiary.update.mockResolvedValue(beneficiary)
+
+    const result = await controller.editById(beneficiary.id, beneficiary)
+    expect(result).toEqual(beneficiary)
+    expect(prismaMock.beneficiary.update).toHaveBeenCalledWith({
+      where: { id: beneficiary.id },
+      data: beneficiary,
+    })
   })
 })

--- a/apps/api/src/beneficiary/beneficiary.service.ts
+++ b/apps/api/src/beneficiary/beneficiary.service.ts
@@ -13,7 +13,10 @@ export class BeneficiaryService {
   }
 
   async listBeneficiaries(): Promise<Beneficiary[]> {
-    return await this.prisma.beneficiary.findMany({ include: { person: true } })
+    return await this.prisma.beneficiary.findMany({
+      include: { person: true },
+      orderBy: [{ person: { firstName: 'asc' } }],
+    })
   }
 
   async viewBeneficiary(id: string): Promise<Beneficiary | null | undefined> {

--- a/apps/api/src/beneficiary/dto/create-beneficiary.dto.ts
+++ b/apps/api/src/beneficiary/dto/create-beneficiary.dto.ts
@@ -1,4 +1,12 @@
-import { IsEnum, IsISO31661Alpha2, IsNotEmpty, IsUUID, IsString, IsOptional } from 'class-validator'
+import {
+  IsEnum,
+  IsISO31661Alpha2,
+  IsNotEmpty,
+  IsUUID,
+  IsString,
+  IsOptional,
+  ValidateIf,
+} from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose } from 'class-transformer'
 import { BeneficiaryType, PersonRelation, Prisma } from '.prisma/client'
@@ -14,7 +22,25 @@ export class CreateBeneficiaryDto {
   @IsNotEmpty()
   @Expose()
   @IsUUID()
+  @IsOptional()
+  @ValidateIf(
+    (data) =>
+      (data.type === BeneficiaryType.individual && data.personId) ||
+      (data.type === BeneficiaryType.company && data.companyId),
+  )
   public readonly personId: string
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @Expose()
+  @IsUUID()
+  @IsOptional()
+  @ValidateIf(
+    (data) =>
+      (data.type === BeneficiaryType.individual && data.personId) ||
+      (data.type === BeneficiaryType.company && data.companyId),
+  )
+  public readonly companyId: string
 
   @ApiProperty()
   @IsNotEmpty()

--- a/apps/api/src/beneficiary/dto/update-beneficiary.dto.ts
+++ b/apps/api/src/beneficiary/dto/update-beneficiary.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsISO31661Alpha2, IsNotEmpty, IsUUID, IsString, IsOptional } from 'class-validator'
+import { IsEnum, IsISO31661Alpha2, IsNotEmpty, IsUUID, IsString, IsOptional, ValidateIf } from 'class-validator'
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose } from 'class-transformer'
 import { BeneficiaryType, PersonRelation, Prisma } from '.prisma/client'
@@ -13,8 +13,26 @@ export class UpdateBeneficiaryDto {
   @ApiProperty()
   @IsNotEmpty()
   @Expose()
+  @IsOptional()
   @IsUUID()
+  @ValidateIf(
+    (data) =>
+      (data.type === BeneficiaryType.individual && data.personId) ||
+      (data.type === BeneficiaryType.company && data.companyId),
+  )
   public readonly personId: string
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @Expose()
+  @IsUUID()
+  @IsOptional()
+  @ValidateIf(
+    (data) =>
+      (data.type === BeneficiaryType.individual && data.personId) ||
+      (data.type === BeneficiaryType.company && data.companyId),
+  )
+  public readonly companyId: string
 
   @ApiProperty()
   @IsNotEmpty()

--- a/apps/api/src/campaign-file/campaign-file.controller.spec.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.spec.ts
@@ -41,7 +41,7 @@ describe('CampaignFileController', () => {
         ConfigService,
         {
           provide: CampaignService,
-          useValue: { getCampaignByIdAndPersonId: jest.fn(() => null) },
+          useValue: { getCampaignByIdAndCoordinatorId: jest.fn(() => null) },
         },
         VaultService,
       ],
@@ -75,7 +75,7 @@ describe('CampaignFileController', () => {
     ).toEqual([fileId, fileId])
 
     expect(personService.findOneByKeycloakId).toHaveBeenCalledWith(userMock.sub)
-    expect(campaignService.getCampaignByIdAndPersonId).not.toHaveBeenCalled()
+    expect(campaignService.getCampaignByIdAndCoordinatorId).not.toHaveBeenCalled()
     expect(campaignFileService.create).toHaveBeenCalledTimes(2)
   })
 
@@ -85,14 +85,14 @@ describe('CampaignFileController', () => {
     await expect(controller.create(campaignId, { roles: [] }, [], userMock)).rejects.toThrowError()
 
     expect(personService.findOneByKeycloakId).toHaveBeenCalledWith(userMock.sub)
-    expect(campaignService.getCampaignByIdAndPersonId).not.toHaveBeenCalled()
+    expect(campaignService.getCampaignByIdAndCoordinatorId).not.toHaveBeenCalled()
   })
 
   it('should throw an error for user not owning updated campaign', async () => {
     await expect(controller.create(campaignId, { roles: [] }, [], userMock)).rejects.toThrowError()
 
     expect(personService.findOneByKeycloakId).toHaveBeenCalledWith(userMock.sub)
-    expect(campaignService.getCampaignByIdAndPersonId).toHaveBeenCalledWith(
+    expect(campaignService.getCampaignByIdAndCoordinatorId).toHaveBeenCalledWith(
       campaignId,
       personIdMock,
     )

--- a/apps/api/src/campaign-file/campaign-file.controller.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.ts
@@ -48,9 +48,14 @@ export class CampaignFileController {
     }
 
     if (!isAdmin(user)) {
-      const campaign = await this.campaignService.getCampaignByIdAndPersonId(campaignId, person.id)
+      const campaign = await this.campaignService.getCampaignByIdAndCoordinatorId(
+        campaignId,
+        person.id,
+      )
       if (!campaign) {
-        throw new NotFoundException('No campaign found for logged user')
+        throw new NotFoundException(
+          'User ' + user.name + 'is not admin or coordinator of campaign with id: ' + campaignId,
+        )
       }
     }
 

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -78,9 +78,12 @@ export class CampaignService {
     return campaign
   }
 
-  async getCampaignByIdAndPersonId(campaignId: string, personId: string): Promise<Campaign | null> {
+  async getCampaignByIdAndCoordinatorId(
+    campaignId: string,
+    coordinatorId: string,
+  ): Promise<Campaign | null> {
     const campaign = await this.prisma.campaign.findFirst({
-      where: { id: campaignId, coordinator: { personId } },
+      where: { id: campaignId, coordinator: { personId: coordinatorId } },
       include: { coordinator: true },
     })
     return campaign
@@ -391,7 +394,7 @@ export class CampaignService {
       throw new UnauthorizedException()
     }
 
-    const campaign = await this.getCampaignByIdAndPersonId(campaignId, person.id)
+    const campaign = await this.getCampaignByIdAndCoordinatorId(campaignId, person.id)
     if (!campaign) {
       throw new UnauthorizedException()
     }

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -10,6 +10,7 @@ import { UpdateExpenseDto } from './dto/update-expense.dto'
 export class ExpensesController {
   constructor(private readonly expensesService: ExpensesService) {}
 
+  @Get('list')
   @Roles({
     roles: [RealmViewSupporters.role, ViewSupporters.role],
     mode: RoleMatchingMode.ANY,

--- a/db/seed/beneficiary.seed.ts
+++ b/db/seed/beneficiary.seed.ts
@@ -26,7 +26,7 @@ export async function beneficiarySeed() {
   }
 
   const insert = await prisma.beneficiary.createMany({
-    data: persons.map((person) => ({
+    data: persons.slice(0, persons.length / 2).map((person) => ({
       type: BeneficiaryType.individual,
       personId: person.id,
       countryCode: bg.countryCode,

--- a/db/seed/coordinator.seed.ts
+++ b/db/seed/coordinator.seed.ts
@@ -16,7 +16,7 @@ export async function coordinatorSeed() {
   })
 
   const insert = await prisma.coordinator.createMany({
-    data: result,
+    data: result.slice(0, result.length / 2),
     skipDuplicates: true,
   })
   console.log({ insert })


### PR DESCRIPTION
Fixing issues related to Admin Crete Beneficiary Form https://github.com/podkrepi-bg/frontend/issues/818
Additional fixes added as noticed while debuging the campaing creation


- fixed: in create/update Beneficiary the personId can be optional, if passing companyId and vice versa
- rename: getCampaignByIdAndPersonId to getCampaignByIdAndCoordinatorId to better reflect that this method is checking if the authenticated user is coordinator of the campaign
- fixed: keycloak.isAdmin function to check for realmRoles too
- fixed: expenses list method was not exposed via API
