### PR TITLE
Fixed prisma migration to ensure campaigns have unique paymentRef code

### DIFF
--- a/migrations/20220605165716_rename_bank_hash_to_payment_reference/migration.sql
+++ b/migrations/20220605165716_rename_bank_hash_to_payment_reference/migration.sql
@@ -9,5 +9,9 @@ ALTER TABLE "campaigns"
 ALTER TABLE "campaigns" 
   ALTER COLUMN "payment_reference" TYPE varchar(15);
 
+-- make sure all payment-refs are unique taking the middle part of the guid id example: '4052-4A03-9B4C'
+UPDATE "campaigns" SET "payment_reference" = upper(substr(id::text, 10, 14))
+WHERE ("payment_reference" IS NULL OR trim("payment_reference") != '' OR length("payment_reference") < 14);
+
 CREATE UNIQUE INDEX "campaigns_payment_reference_key" ON "campaigns"("payment_reference");
 


### PR DESCRIPTION
Fixes https://github.com/podkrepi-bg/api/issues/260

The migration was failing due to CREATE UNIQUE INDEX over a column of potentially empty or not unique bankHashes

Now to make sure all for exisiting campaings payment-refs are unique update with the middle part of the guid id example: '4052-4A03-9B4C'
```UPDATE "campaigns" SET "payment_reference" = upper(substr(id::text, 10, 14))
WHERE ("payment_reference" IS NULL OR trim("payment_reference") != '' OR length("payment_reference") < 14);
```
