### PR TITLE
GetDonationsByUserId to return campaign title only

### DIFF
--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -84,7 +84,7 @@ export class DonationsService {
   async listDonations(campaignId?: string): Promise<Donation[]> {
     if (campaignId) {
       return await this.prisma.donation.findMany({
-        where: { targetVault: {campaign: {id: campaignId}} },
+        where: { targetVault: { campaign: { id: campaignId } } },
         orderBy: [{ createdAt: 'desc' }],
       })
     } else {
@@ -143,7 +143,6 @@ export class DonationsService {
     DonationsDto: CreateManyBankPaymentsDto[],
   ): Promise<Prisma.BatchPayload> {
     try {
-
       const donations = await this.prisma.donation.createMany({ data: DonationsDto })
 
       // Donation status check is not needed, because bank payments are only added by admins if the bank transfer was successful.
@@ -158,8 +157,6 @@ export class DonationsService {
       Logger.warn(error)
       throw new BadRequestException(error)
     }
-
-
   }
 
   async update(id: string, updatePaymentDto: UpdatePaymentDto): Promise<Donation> {
@@ -215,7 +212,7 @@ export class DonationsService {
     const donations = await this.prisma.donation.findMany({
       include: {
         targetVault: {
-          include: { campaign: true },
+          include: { campaign: { select: { title: true } } },
         },
       },
       where: { person: { keycloakId } },

--- a/db/seed/donations.seed.ts
+++ b/db/seed/donations.seed.ts
@@ -1,4 +1,10 @@
-import { CampaignState, Currency, PrismaClient } from '@prisma/client'
+import {
+  CampaignState,
+  Currency,
+  PrismaClient,
+  PaymentProvider,
+  DonationStatus,
+} from '@prisma/client'
 import faker from 'faker'
 const prisma = new PrismaClient()
 
@@ -27,6 +33,8 @@ export async function donationsSeed() {
         extCustomerId: 'cus_' + faker.random.alphaNumeric(8),
         extPaymentIntentId: 'pi_' + faker.random.alphaNumeric(8),
         extPaymentMethodId: 'pm_' + faker.random.alphaNumeric(8),
+        provider: PaymentProvider.stripe,
+        status: DonationStatus.succeeded,
       },
       {
         type: 'donation',
@@ -37,6 +45,8 @@ export async function donationsSeed() {
         extCustomerId: 'cus_' + faker.random.alphaNumeric(8),
         extPaymentIntentId: 'pi_' + faker.random.alphaNumeric(8),
         extPaymentMethodId: 'pm_' + faker.random.alphaNumeric(8),
+        provider: PaymentProvider.bank,
+        status: DonationStatus.initial,
       },
       {
         type: 'donation',
@@ -47,6 +57,8 @@ export async function donationsSeed() {
         extCustomerId: 'cus_' + faker.random.alphaNumeric(8),
         extPaymentIntentId: 'pi_' + faker.random.alphaNumeric(8),
         extPaymentMethodId: 'pm_' + faker.random.alphaNumeric(8),
+        provider: PaymentProvider.stripe,
+        status: DonationStatus.declined,
       },
     ],
     skipDuplicates: true,


### PR DESCRIPTION
- fixed: getDonationsByUser to return only the Campaign title instead of the full campaign entity
- added: donation seeding to create donations with different provider and status
