### PR TITLE
extended: response object with vaults and incomingTransfers

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -78,7 +78,11 @@ export class CampaignService {
   async getCampaignById(campaignId: string): Promise<Campaign> {
     const campaign = await this.prisma.campaign.findFirst({
       where: { id: campaignId },
-      include: { campaignFiles: true },
+      include: {
+        campaignFiles: true,
+        vaults: { select: { donations: { select: { amount: true } }, amount: true } },
+        incomingTransfers: { select: { amount: true } },
+      },
     })
     if (!campaign) {
       Logger.warn('No campaign record with ID: ' + campaignId)


### PR DESCRIPTION
Added `vaults` and `incomingTransfers` to campaign response in getCampaignById(id) used in edit campaign form in the admin.