### PR TITLE
CampaignType slug and category added to campaign response

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -63,7 +63,7 @@ export class CampaignService {
         endDate: 'asc',
       },
       include: {
-        campaignType: { select: { name: true } },
+        campaignType: { select: { name: true, slug: true } },
         beneficiary: { select: { person: { select: { firstName: true, lastName: true } } } },
         coordinator: { select: { person: { select: { firstName: true, lastName: true } } } },
         organizer: { select: { person: { select: { firstName: true, lastName: true } } } },
@@ -125,7 +125,7 @@ export class CampaignService {
       where: { slug },
       include: {
         campaignType: {
-          select: { name: true },
+          select: { name: true, slug: true, category: true },
         },
         beneficiary: {
           select: {


### PR DESCRIPTION
Both properties are used for translation of campaign category and type on the frontend