### PR TITLE
OneTimeDonation to create initial donation record for tracking purposes

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -251,6 +251,7 @@ export class CampaignService {
   async createDraftDonation(
     campaign: Campaign,
     paymentIntent: Stripe.PaymentIntent,
+    status?: DonationStatus,
   ): Promise<Donation> {
     const campaignId = campaign.id
     const { currency } = campaign
@@ -277,7 +278,7 @@ export class CampaignService {
         targetVault,
         provider: PaymentProvider.stripe,
         type: DonationType.donation,
-        status: DonationStatus.waiting,
+        status: status ? status : DonationStatus.waiting,
         extCustomerId: this.getCustomerId(paymentIntent),
         extPaymentIntentId: paymentIntent.id,
         extPaymentMethodId: this.getPaymentMehtodId(paymentIntent),

--- a/apps/api/src/donations/donations.controller.spec.ts
+++ b/apps/api/src/donations/donations.controller.spec.ts
@@ -16,6 +16,8 @@ describe('DonationsController', () => {
   const stripeMock = {
     checkout: { sessions: { create: jest.fn() } },
   }
+  stripeMock.checkout.sessions.create.mockReturnValue({ payment_intent: 'unique-intent' })
+
   const mockSession = {
     mode: 'payment',
     priceId: 'testPriceId',

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -46,7 +46,6 @@ export class DonationsService {
     sessionDto: CreateSessionDto,
     paymentIntent: string,
   ): Promise<Donation> {
-
     const campaignId = campaign.id
     const { currency } = campaign
     const amount = sessionDto.amount
@@ -97,7 +96,6 @@ export class DonationsService {
   async createCheckoutSession(
     sessionDto: CreateSessionDto,
   ): Promise<{ session: Stripe.Checkout.Session }> {
-
     const campaign = await this.campaignService.validateCampaignId(sessionDto.campaignId)
     const { mode } = sessionDto
     const appUrl = this.config.get<string>('APP_URL')

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -49,6 +49,7 @@ export class DonationsService {
 
     const session = await this.stripeClient.checkout.sessions.create({
       mode,
+      customer_email: sessionDto.personEmail,
       line_items: this.prepareSessionItems(sessionDto, campaign),
       payment_method_types: ['card'],
       payment_intent_data: mode === 'payment' ? { metadata } : undefined,
@@ -64,12 +65,6 @@ export class DonationsService {
 
     const vault = await this.campaignService.getCampaignVault(campaign.id)
 
-    const user = {
-      firsName: 'Ivaylo',
-      lastName: 'Stoychev',
-      email: 'ivo90@mail.bg',
-      phone: '0877595926',
-    }
     /**
      * Create donation object
      */
@@ -89,13 +84,13 @@ export class DonationsService {
         person: {
           connectOrCreate: {
             where: {
-              email: user.email,
+              email: sessionDto.personEmail as string,
             },
             create: {
-              firstName: user.firsName,
-              lastName: user.lastName,
-              email: user.email,
-              phone: user.phone,
+              firstName: sessionDto.firstName ?? 'Anonymous',
+              lastName: sessionDto.lastName ?? 'Donor',
+              email: sessionDto.personEmail as string,
+              phone: sessionDto.phone,
             },
           },
         },

--- a/apps/api/src/donations/dto/create-session.dto.ts
+++ b/apps/api/src/donations/dto/create-session.dto.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe'
 import { Expose } from 'class-transformer'
 import { ApiProperty } from '@nestjs/swagger'
 import {
+  IsEmail,
   IsIn,
   IsNotEmpty,
   IsNumber,
@@ -42,6 +43,31 @@ export class CreateSessionDto {
   @IsNotEmpty()
   @IsUUID()
   public readonly campaignId: string
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  firstName: string | null
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  lastName: string | null
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  phone: string | null
+
+  @Expose()
+  @ApiProperty()
+  @IsString()
+  @IsOptional()
+  @IsEmail()
+  personEmail: string
 
   @ApiProperty()
   @Expose()


### PR DESCRIPTION
When creating donation, we want to record the inital donation before relying on stripe events to send it to us.

- stored donation after create session
- without draft donation
- stored donation with connected person
- fixed: creation of initialDonation object
- fixed donation tests: was failing due to the new initial donation creation
