### PR TITLE
allow donations on approved campaign

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -350,13 +350,15 @@ export class CampaignService {
   async validateCampaign(campaign: Campaign): Promise<Campaign> {
     const canAcceptDonation = await this.canAcceptDonations(campaign)
     if (!canAcceptDonation) {
-      throw new NotAcceptableException('This campaign cannot accept donations')
+      throw new NotAcceptableException(
+        'Campaign cannot accept donations in state: ' + campaign.state,
+      )
     }
     return campaign
   }
 
   async canAcceptDonations(campaign: Campaign): Promise<boolean> {
-    const validStates: CampaignState[] = [CampaignState.active]
+    const validStates: CampaignState[] = [CampaignState.active, CampaignState.approved]
     if (campaign.allowDonationOnComplete) {
       validStates.push(CampaignState.complete)
     }

--- a/apps/api/src/donations/donations.controller.spec.ts
+++ b/apps/api/src/donations/donations.controller.spec.ts
@@ -92,7 +92,7 @@ describe('DonationsController', () => {
     } as Campaign)
 
     await expect(controller.createCheckoutSession(mockSession)).rejects.toThrow(
-      new NotAcceptableException('This campaign cannot accept donations'),
+      new NotAcceptableException('Campaign cannot accept donations in state: complete'),
     )
     expect(prismaMock.campaign.findFirst).toHaveBeenCalled()
     expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled()


### PR DESCRIPTION
As part of campaign preparation we have to allow donations on approved campaign - it is still not visible publicly, but can be reached from AdminUI
