### PR TITLE
Anonymous donation to not connect person

### DIFF
--- a/apps/api/src/donations/donations.controller.spec.ts
+++ b/apps/api/src/donations/donations.controller.spec.ts
@@ -24,6 +24,7 @@ describe('DonationsController', () => {
     campaignId: 'testCampaignId',
     successUrl: 'http://test.com',
     cancelUrl: 'http://test.com',
+    isAnonymous: true,
   } as CreateSessionDto
 
   beforeEach(async () => {

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -73,22 +73,31 @@ export class DonationsService {
         extCustomerId: sessionDto.personEmail ?? '',
         extPaymentIntentId: paymentIntentId,
         extPaymentMethodId: 'card',
+        billingEmail: sessionDto.isAnonymous ? sessionDto.personEmail : null, //set the personal mail to billing which is not public field
         targetVault: targetVaultData,
-        person: {
-          connectOrCreate: {
-            where: {
-              email: sessionDto.personEmail ?? 'anonymous@podkrepi.bg',
-            },
-            create: {
-              firstName: sessionDto.firstName ?? 'Anonymous',
-              lastName: sessionDto.lastName ?? 'Donor',
-              email: sessionDto.personEmail ?? 'anonymous@podkrepi.bg',
-              phone: sessionDto.phone,
+      },
+    })
+
+    if (!sessionDto.isAnonymous) {
+      await this.prisma.donation.update({
+        where: { id: donation.id },
+        data: {
+          person: {
+            connectOrCreate: {
+              where: {
+                email: sessionDto.personEmail,
+              },
+              create: {
+                firstName: sessionDto.firstName ?? '',
+                lastName: sessionDto.lastName ?? '',
+                email: sessionDto.personEmail,
+                phone: sessionDto.phone,
+              },
             },
           },
         },
-      },
-    })
+      })
+    }
 
     return donation
   }

--- a/apps/api/src/donations/dto/create-session.dto.ts
+++ b/apps/api/src/donations/dto/create-session.dto.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe'
 import { Expose } from 'class-transformer'
 import { ApiProperty } from '@nestjs/swagger'
 import {
+  IsBoolean,
   IsEmail,
   IsIn,
   IsNotEmpty,
@@ -68,6 +69,11 @@ export class CreateSessionDto {
   @IsOptional()
   @IsEmail()
   personEmail: string
+
+  @Expose()
+  @ApiProperty()
+  @IsBoolean()
+  isAnonymous: boolean
 
   @ApiProperty()
   @Expose()


### PR DESCRIPTION
Fixed, now donation request contains isAnonymous flag. The anonymous donation record does not create or connect a person record anymore.
