### PR TITLE
fix extCustomerId none vs undefined

### DIFF
--- a/apps/api/src/donations/events/payment-intent-helpers.ts
+++ b/apps/api/src/donations/events/payment-intent-helpers.ts
@@ -1,10 +1,17 @@
 import Stripe from 'stripe'
 
-function getPaymentMethodId(paymentIntent: Stripe.PaymentIntent): string | 'none' {
+function getPaymentMethodId(paymentIntent: Stripe.PaymentIntent): string | undefined {
   if (typeof paymentIntent.payment_method === 'string') {
     return paymentIntent.payment_method
   }
-  return paymentIntent.payment_method?.id ?? 'none'
+  return paymentIntent.payment_method?.id ?? undefined
+}
+
+function getPaymentCustomerId(paymentIntent: Stripe.PaymentIntent): string | undefined {
+  if (typeof paymentIntent.customer === 'string') {
+    return paymentIntent.customer
+  }
+  return paymentIntent.customer?.id ?? undefined
 }
 
 export type PaymentData = {
@@ -27,6 +34,6 @@ export function getPaymentData(paymentIntent: Stripe.PaymentIntent): PaymentData
     billingName: billingDetails?.name ?? undefined,
     billingEmail: billingDetails?.email ?? paymentIntent.receipt_email ?? undefined,
     paymentMethodId: getPaymentMethodId(paymentIntent),
-    stripeCustomerId: paymentIntent.customer as string | undefined,
+    stripeCustomerId: getPaymentCustomerId(paymentIntent),
   }
 }

--- a/manifests/overlays/production/keycloak-config.patch.yaml
+++ b/manifests/overlays/production/keycloak-config.patch.yaml
@@ -4,3 +4,4 @@ metadata:
   name: keycloak-config
 data:
   realm: webapp
+  url: https://keycloak-dev.podkrepi.bg

--- a/manifests/overlays/production/kustomization.yaml
+++ b/manifests/overlays/production/kustomization.yaml
@@ -13,9 +13,9 @@ patches:
 
 images:
   - name: ghcr.io/podkrepi-bg/api
-    newTag: v0.4.1
+    newTag: v0.4.2
   - name: ghcr.io/podkrepi-bg/api/migrations
-    newTag: v0.4.1
+    newTag: v0.4.2
 #secretGenerator:
 #  - name: stripe-secret
 #    envs: [stripe.env]

--- a/manifests/overlays/production/kustomization.yaml
+++ b/manifests/overlays/production/kustomization.yaml
@@ -13,11 +13,10 @@ patches:
 
 images:
   - name: ghcr.io/podkrepi-bg/api
-    newTag: v0.4.0
+    newTag: v0.4.1
   - name: ghcr.io/podkrepi-bg/api/migrations
-    newTag: v0.4.0
-
-secretGenerator:
+    newTag: v0.4.1
+#secretGenerator:
 #  - name: stripe-secret
 #    envs: [stripe.env]
 #  - name: keycloak-secret

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podkrepi-bg-api",
-  "version": "0.3.5",
+  "version": "0.4.2",
   "license": "MIT",
   "repository": "https://github.com/orgs/podkrepi-bg",
   "scripts": {


### PR DESCRIPTION
Fixed the way we extract extCustomerId from stripePayment intent as it breaks the upsert in database

- updated: kustomize deployment for production
- fixed:extCustomerId and extPaymentId from none to undefined
- bumped version to v0.4.2
