### PR TITLE
Safer handling of Stripe events

### DIFF
--- a/apps/api/src/donations/events/donation-status-updates.ts
+++ b/apps/api/src/donations/events/donation-status-updates.ts
@@ -1,0 +1,21 @@
+import { DonationStatus } from '@prisma/client'
+
+/**
+ * The function returns the allowed previous status that can be changed/updated by the incoming donation event
+ * @param newStatus the incoming status of the payment event
+ * @returns allowed previous status that can be changed by the event
+ */
+export function getAllowedPreviousStatus(newStatus: DonationStatus): DonationStatus | undefined {
+  switch (newStatus) {
+    case DonationStatus.waiting: {
+      return DonationStatus.initial
+    }
+    case DonationStatus.succeeded: {
+      return DonationStatus.waiting
+    }
+    case DonationStatus.cancelled: {
+      return DonationStatus.waiting
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
When handling payment events from Stripe, in cases of repated event we should not allow earlier event to override a donation already updated with later update.
Example:
If in database we have donationStatus=succeeded we should not update it with a repeated donationStatus=waiting
If in database we have donationStatus=waiting we can update it with incoming donationStatus=waiting or donationStatus=succesful or cancelled


