### PR TITLE
Fix loading single campaign after upgrade ot Prisma4

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -108,7 +108,7 @@ export class CampaignService {
         ) as d
         on d.target_vault_id = v.id
       GROUP BY v.campaign_id
-      HAVING v.campaign_id in (${Prisma.join(campaignIds)})
+      HAVING v.campaign_id::TEXT in (${Prisma.join(campaignIds)})
       `
       campaignSums = result || []
     } else {


### PR DESCRIPTION
Loading single campaing was not working after upgrade ot Prisma4.
Fixed by adding explictit conversion of camapignId field to TEXT in prisma.queryRaw. This was working in prisma3 before.
