### PR TITLE
359 - One postgres instance for both keycloak and general database

### DIFF
--- a/.env
+++ b/.env
@@ -46,7 +46,7 @@ S3_SECRET_ACCESS_KEY=s3-secret-access-key
 
 ## Keycloak ##
 ##############
-KEYCLOAK_URL=http://localhost:8080/auth
+KEYCLOAK_URL=http://localhost:8180/auth
 KEYCLOAK_REALM=webapp
 KEYCLOAK_CLIENT_ID=jwt-headless
 KEYCLOAK_SECRET=DEV-KEYCLOAK-SECRET

--- a/.env
+++ b/.env
@@ -27,6 +27,13 @@ DB_PASS=postgrespass
 DB_PORT=5432
 DB_NAME=postgres
 
+## Keycloak  ##
+##############
+KEYCLOAK_DB_VENDOR=POSTGRES
+KEYCLOAK_DB_USER=keycloak
+KEYCLOAK_DB_PASSWORD=keycloak
+KEYCLOAK_DB_NAME=keycloak
+
 ## Local prisma db url
 DATABASE_URL=postgres://postgres:postgrespass@localhost:5432/postgres?schema=api
 
@@ -39,7 +46,7 @@ S3_SECRET_ACCESS_KEY=s3-secret-access-key
 
 ## Keycloak ##
 ##############
-KEYCLOAK_URL=http://localhost:8180/auth
+KEYCLOAK_URL=http://localhost:8080/auth
 KEYCLOAK_REALM=webapp
 KEYCLOAK_CLIENT_ID=jwt-headless
 KEYCLOAK_SECRET=DEV-KEYCLOAK-SECRET

--- a/db/init.d/create-keycloak-db.sh
+++ b/db/init.d/create-keycloak-db.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -u
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE USER keycloak WITH PASSWORD 'keycloak';
+    CREATE DATABASE keycloak;
+    GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;

--- a/db/init.d/init.sql
+++ b/db/init.d/init.sql
@@ -2,3 +2,4 @@
 \set ON_ERROR_STOP on
 
 CREATE SCHEMA "api";
+CREATE SCHEMA "public";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     restart: always
 
     volumes:
-      - keycloak-db-data:/var/lib/postgresql/data
+      - keycloak-db-data:/var/lib/keycloak
       - pg-db-data:/var/lib/postgresql/data
     ports:
       - '${DB_PORT?}:5432'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
     restart: always
 
     volumes:
+      # Keycloak creates it's own /data and /conf folders
       - keycloak-db-data:/var/lib/keycloak
       - pg-db-data:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,8 +81,8 @@ services:
     restart: always
 
     volumes:
-      - pg-db-data:/bitnami/postgresql
-
+      - keycloak-db-data:/var/lib/postgresql/data
+      - pg-db-data:/var/lib/postgresql/data
     ports:
       - '${DB_PORT?}:5432'
 
@@ -113,21 +113,21 @@ services:
       - KEYCLOAK_IMPORT=/opt/jboss/keycloak/config/keycloak-webapp-realm.json
       - DEBUG=true
       - DEBUG_PORT='*:8787'
-      - DB_VENDOR=POSTGRES
-      - DB_USER=keycloak
-      - DB_PASSWORD=keycloak
+      - DB_VENDOR=${KEYCLOAK_DB_VENDOR?}
+      - DB_USER=${KEYCLOAK_DB_USER?}
+      - DB_PASSWORD=${KEYCLOAK_DB_PASSWORD?}
       - DB_ADDR=${COMPOSE_PROJECT_NAME?}-pg-db
-      - DB_DATABASE=keycloak
+      - DB_DATABASE=${KEYCLOAK_DB_NAME?}
     ports:
       - '8180:8080'
       - '8787:8787'
     volumes:
       - './manifests/keycloak/theme_podkrepi:/opt/jboss/keycloak/themes/theme_podkrepi'
       - './manifests/keycloak/config:/opt/jboss/keycloak/config'
-    networks:
-      backend-net:
     depends_on:
       - pg-db
+    networks:
+      - backend-net
 
   # ## KEYCLOAK CONFIGURATOR - removes the need to recreate keycloak container upon config changes
   # ## uncomment if you plan to tune the keycloak realm configuration
@@ -151,6 +151,7 @@ services:
   #     backend-net:
 volumes:
   pg-db-data:
+    driver: local
   keycloak-db-data:
     driver: local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     restart: 'no'
     environment:
       DATABASE_URL: postgres://${DB_USER?}:${DB_PASS?}@${DB_HOST?}:${DB_PORT?}/${DB_NAME?}?schema=api
-    entrypoint: ["sh", "-c", "sleep 5 && yarn prisma migrate deploy"]
+    entrypoint: ['sh', '-c', 'sleep 5 && yarn prisma migrate deploy']
     depends_on:
       - pg-db
     networks:
@@ -65,7 +65,7 @@ services:
     restart: 'no'
     environment:
       DATABASE_URL: postgres://${DB_USER?}:${DB_PASS?}@${DB_HOST?}:${DB_PORT?}/${DB_NAME?}?schema=api
-    entrypoint: ["sh", "-c", "sleep 15 && yarn prisma generate && yarn prisma db seed"]
+    entrypoint: ['sh', '-c', 'sleep 15 && yarn prisma generate && yarn prisma db seed']
     depends_on:
       - pg-db
     networks:
@@ -95,7 +95,6 @@ services:
 
     networks:
       - backend-net
-
   ########################################
   ## LOCAL IDENTITY PROVIDER - KEYCLOAK ##
   ########################################
@@ -108,22 +107,27 @@ services:
     profiles: ['local-keycloak']
     restart: always
     environment:
-      - KEYCLOAK_USER=${KEYCLOAK_PASSWORD}
-      - KEYCLOAK_PASSWORD=${KEYCLOAK_PASSWORD}
+      - KEYCLOAK_USER=${KEYCLOAK_USER?}
+      - KEYCLOAK_PASSWORD=${KEYCLOAK_PASSWORD?}
       - JAVA_OPTS_APPEND=-Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled
       - KEYCLOAK_IMPORT=/opt/jboss/keycloak/config/keycloak-webapp-realm.json
       - DEBUG=true
       - DEBUG_PORT='*:8787'
-      - DB_VENDOR=H2
-      - TZ=Europe/Sofia
+      - DB_VENDOR=POSTGRES
+      - DB_USER=keycloak
+      - DB_PASSWORD=keycloak
+      - DB_ADDR=${COMPOSE_PROJECT_NAME?}-pg-db
+      - DB_DATABASE=keycloak
     ports:
-      - '8180:8080'
+      - '8080:8080'
       - '8787:8787'
     volumes:
       - './manifests/keycloak/theme_podkrepi:/opt/jboss/keycloak/themes/theme_podkrepi'
       - './manifests/keycloak/config:/opt/jboss/keycloak/config'
     networks:
       backend-net:
+    depends_on:
+      - pg-db
 
   # ## KEYCLOAK CONFIGURATOR - removes the need to recreate keycloak container upon config changes
   # ## uncomment if you plan to tune the keycloak realm configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - DB_ADDR=${COMPOSE_PROJECT_NAME?}-pg-db
       - DB_DATABASE=keycloak
     ports:
-      - '8080:8080'
+      - '8180:8080'
       - '8787:8787'
     volumes:
       - './manifests/keycloak/theme_podkrepi:/opt/jboss/keycloak/themes/theme_podkrepi'


### PR DESCRIPTION
Solves #359 

* Added a script to create a `keycloak` database on the current `postgres` instance.
* Changed the `keycloak` to now connect to the newly created database

Made the changes that @imilchev proposed in an old issue https://github.com/podkrepi-bg/infrastructure/issues/17 in the infrastructure repo. 
I don't know if it is still relevant though or if he is talking specifically about the infrastructure as code that is being deployed . In any case if it is needed in the infrastructure repo the solution should be similar

Notes:
There is a `CREATE SCHEMA "public";` line in the `init.sql` file which I am unsure if is relevant in any way, but couldn't test it.

This is how the file structure in the pg-db container looks like:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/61479393/202183747-183feb6e-7f0e-424a-8a94-39220ac9091d.png">

Is that right considering we have 2 databases now @imilchev?

