### PR TITLE
Update outdated docs discrepancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ To run and develop the module NodeJS 16 is required. In this section 2 ways of c
 
 The following prerequisites are required in order to be able to run the project:
 
-- [NodeJS 16 LTS](https://nodejs.org/en/download/)
-- [yarn](https://classic.yarnpkg.com/lang/en/docs/install)
+- [Node.js 16 LTS](https://nodejs.org/en/download/)
+- [Yarn v1.x](https://classic.yarnpkg.com/lang/en/docs/install)
 - [Docker](https://www.docker.com/get-started) (to easily run a local database instance)
 
 ## Development container
@@ -147,7 +147,7 @@ docker-compose down
 
 ## API Docs via Swagger
 
-Available at <http://localhost:5010/docs/>
+Available at <http://localhost:5010/swagger/>
 
 ## Understand your workspace
 
@@ -272,9 +272,11 @@ s3cmd ls
 ```
 
 # Configuring Google Sign-in with Keycloak
-For enabling sign-in with existing gmail account we use the token-exchange feature of Keycloak as per the great description in: https://medium.com/@souringhosh/keycloak-token-exchange-usage-with-google-sign-in-cd9127ebc96d 
+
+For enabling sign-in with existing gmail account we use the token-exchange feature of Keycloak as per the great description in: https://medium.com/@souringhosh/keycloak-token-exchange-usage-with-google-sign-in-cd9127ebc96d
 
 The logic is the following:
+
 1. The frontend acquires a token from Google Sign-in
 2. The frontend sends the token to the backend API requesting a login with external provider (see: auth.service.ts issueTokenFromProvider)
 3. The backend sends the token-exchange request to Keycloak passing the Google Token for Permission to Login

--- a/apps/api/src/app/app.controller.spec.ts
+++ b/apps/api/src/app/app.controller.spec.ts
@@ -14,12 +14,12 @@ describe('AppController', () => {
   })
 
   describe('getData', () => {
-    it('should return "Welcome to Podkrepi.bg Backend API! See Swagger docs at /docs"', () => {
+    it('should return "Welcome to Podkrepi.bg Backend API! See Swagger docs at /swagger"', () => {
       const appVersion = process.env.APP_VERSION || 'unknown'
       const appController = app.get<AppController>(AppController)
       expect(appController.getData()).toEqual({
         version: appVersion,
-        message: 'Welcome to Podkrepi.bg Backend API! See Swagger docs at /docs',
+        message: 'Welcome to Podkrepi.bg Backend API! See Swagger docs at /swagger',
       })
     })
   })

--- a/apps/api/src/app/app.service.spec.ts
+++ b/apps/api/src/app/app.service.spec.ts
@@ -14,11 +14,11 @@ describe('AppService', () => {
   })
 
   describe('getData', () => {
-    it('should return "Welcome to Podkrepi.bg Backend API! See Swagger docs at /docs"', () => {
+    it('should return "Welcome to Podkrepi.bg Backend API! See Swagger docs at /swagger"', () => {
       const appVersion = process.env.APP_VERSION || 'unknown'
       expect(service.getData()).toEqual({
         version: appVersion,
-        message: 'Welcome to Podkrepi.bg Backend API! See Swagger docs at /docs',
+        message: 'Welcome to Podkrepi.bg Backend API! See Swagger docs at /swagger',
       })
     })
   })

--- a/apps/api/src/app/app.service.ts
+++ b/apps/api/src/app/app.service.ts
@@ -11,7 +11,7 @@ export class AppService {
   getData(): { version: string; message: string } {
     return {
       version: this.appVersion,
-      message: 'Welcome to Podkrepi.bg Backend API! See Swagger docs at /docs',
+      message: 'Welcome to Podkrepi.bg Backend API! See Swagger docs at /swagger',
     }
   }
 }


### PR DESCRIPTION
Update outdated docs discrepancies

- update the default API endpoint welcome message to refer to "/swagger"
  instead of "/docs" which is no longer a valid url
- update the README to specify that Yarn v1.x is a mandatory requirement
