### PR TITLE
366 Create a api-logs file containing the logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 /connect.lock
 /coverage
 /libpeerconnection.log
+api-error.log
 npm-debug.log
 yarn-error.log
 testem.log

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@
 /connect.lock
 /coverage
 /libpeerconnection.log
-api-error.log
+/api-logs
 npm-debug.log
 yarn-error.log
 testem.log

--- a/apps/api/src/app/PodkrepiLogger.ts
+++ b/apps/api/src/app/PodkrepiLogger.ts
@@ -1,5 +1,5 @@
 import { ConsoleLogger, LogLevel } from '@nestjs/common'
-import { createFile } from '../common/helpers/storage.helper'
+import { appendToFile } from '../common/helpers/storage.helper'
 
 export class PodkrepiLogger extends ConsoleLogger {
   constructor(logLevels?: LogLevel[]) {
@@ -10,20 +10,23 @@ export class PodkrepiLogger extends ConsoleLogger {
     super.log(message)
   }
 
-  error(message: string) {
-    createFile('/', 'api-error.log', message)
-    super.error(message)
+  error(message: string, ...args) {
+    appendToFile('api-logs', 'api-error.log', message)
+    super.error(message, args)
   }
 
   warn(message: string) {
+    appendToFile('api-logs', 'api-warn.log', message)
     super.warn(message)
   }
 
   debug(message: string) {
+    appendToFile('api-logs', 'api-debug.log', message)
     super.debug(message)
   }
 
   verbose(message: string) {
+    appendToFile('api-logs', 'api-verbose.log', message)
     super.verbose(message)
   }
 }

--- a/apps/api/src/app/PodkrepiLogger.ts
+++ b/apps/api/src/app/PodkrepiLogger.ts
@@ -10,23 +10,23 @@ export class PodkrepiLogger extends ConsoleLogger {
     super.log(message)
   }
 
-  error(message: string, ...args) {
-    appendToFile('api-logs', 'api-error.log', message)
-    super.error(message, args)
+  error(message: string) {
+    appendToFile('api-logs', 'api-error.log', `\n[ERROR] - ${message}`)
+    super.error(message)
   }
 
   warn(message: string) {
-    appendToFile('api-logs', 'api-warn.log', message)
+    appendToFile('api-logs', 'api-warn.log', `\n[WARN] - ${message}`)
     super.warn(message)
   }
 
   debug(message: string) {
-    appendToFile('api-logs', 'api-debug.log', message)
+    appendToFile('api-logs', 'api-debug.log', `\n[DEBUG] - ${message}`)
     super.debug(message)
   }
 
   verbose(message: string) {
-    appendToFile('api-logs', 'api-verbose.log', message)
+    appendToFile('api-logs', 'api-verbose.log', `\n[VERBOSE] - ${message}`)
     super.verbose(message)
   }
 }

--- a/apps/api/src/app/PodkrepiLogger.ts
+++ b/apps/api/src/app/PodkrepiLogger.ts
@@ -1,9 +1,20 @@
 import { ConsoleLogger, LogLevel } from '@nestjs/common'
 import { appendToFile } from '../common/helpers/storage.helper'
 
+export enum LogLevelEnum {
+  LOG = 'log',
+  ERROR = 'error',
+  WARN = 'warn',
+  DEBUG = 'debug',
+  VERBOSE = 'verbose',
+}
 export class PodkrepiLogger extends ConsoleLogger {
   constructor(logLevels?: LogLevel[]) {
     super('PodkrepiLogger', { logLevels })
+  }
+
+  private formatLog(message: string, level: LogLevelEnum = LogLevelEnum.LOG) {
+    return `\n[${level.toUpperCase()}] - ${new Date().toLocaleString()} - ${message}`
   }
 
   log(message: string) {
@@ -11,22 +22,22 @@ export class PodkrepiLogger extends ConsoleLogger {
   }
 
   error(message: string) {
-    appendToFile('api-logs', 'api-error.log', `\n[ERROR] - ${message}`)
+    appendToFile('api-logs', 'api-error.log', this.formatLog(message, LogLevelEnum.ERROR))
     super.error(message)
   }
 
   warn(message: string) {
-    appendToFile('api-logs', 'api-warn.log', `\n[WARN] - ${message}`)
+    appendToFile('api-logs', 'api-warn.log', this.formatLog(message, LogLevelEnum.WARN))
     super.warn(message)
   }
 
   debug(message: string) {
-    appendToFile('api-logs', 'api-debug.log', `\n[DEBUG] - ${message}`)
+    appendToFile('api-logs', 'api-debug.log', this.formatLog(message, LogLevelEnum.DEBUG))
     super.debug(message)
   }
 
   verbose(message: string) {
-    appendToFile('api-logs', 'api-verbose.log', `\n[VERBOSE] - ${message}`)
+    appendToFile('api-logs', 'api-verbose.log', this.formatLog(message, LogLevelEnum.VERBOSE))
     super.verbose(message)
   }
 }

--- a/apps/api/src/app/PodkrepiLogger.ts
+++ b/apps/api/src/app/PodkrepiLogger.ts
@@ -5,39 +5,24 @@ export class PodkrepiLogger extends ConsoleLogger {
   constructor(logLevels?: LogLevel[]) {
     super('PodkrepiLogger', { logLevels })
   }
-  /**
-   * Write a 'log' level log.
-   */
+
   log(message: string) {
     super.log(message)
   }
 
-  /**
-   * Write an 'error' level log.
-   */
   error(message: string) {
-    // write the message to a file, send it to the database or do anything
     createFile('/', 'api-error.log', message)
     super.error(message)
   }
 
-  /**
-   * Write a 'warn' level log.
-   */
   warn(message: string) {
     super.warn(message)
   }
 
-  /**
-   * Write a 'debug' level log.
-   */
   debug(message: string) {
     super.debug(message)
   }
 
-  /**
-   * Write a 'verbose' level log.
-   */
   verbose(message: string) {
     super.verbose(message)
   }

--- a/apps/api/src/app/PodkrepiLogger.ts
+++ b/apps/api/src/app/PodkrepiLogger.ts
@@ -1,0 +1,44 @@
+import { ConsoleLogger, LogLevel } from '@nestjs/common'
+import { createFile } from '../common/helpers/storage.helper'
+
+export class PodkrepiLogger extends ConsoleLogger {
+  constructor(logLevels?: LogLevel[]) {
+    super('PodkrepiLogger', { logLevels })
+  }
+  /**
+   * Write a 'log' level log.
+   */
+  log(message: string) {
+    super.log(message)
+  }
+
+  /**
+   * Write an 'error' level log.
+   */
+  error(message: string) {
+    // write the message to a file, send it to the database or do anything
+    createFile('/', 'api-error.log', message)
+    super.error(message)
+  }
+
+  /**
+   * Write a 'warn' level log.
+   */
+  warn(message: string) {
+    super.warn(message)
+  }
+
+  /**
+   * Write a 'debug' level log.
+   */
+  debug(message: string) {
+    super.debug(message)
+  }
+
+  /**
+   * Write a 'verbose' level log.
+   */
+  verbose(message: string) {
+    super.verbose(message)
+  }
+}

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -46,7 +46,6 @@ import { OrganizerModule } from '../organizer/organizer.module'
 import { DonationWishModule } from '../donation-wish/donation-wish.module'
 import { ApiLoggerMiddleware } from './middleware/apilogger.middleware'
 import { PaypalModule } from '../paypal/paypal.module'
-
 @Module({
   imports: [
     ConfigModule.forRoot({ validationSchema, isGlobal: true, load: [configuration] }),

--- a/apps/api/src/common/helpers/storage.helper.ts
+++ b/apps/api/src/common/helpers/storage.helper.ts
@@ -27,7 +27,7 @@ export const getFile = async (path: string, encoding: BufferEncoding): Promise<s
 }
 
 /**
- * Writes a file at a given path via a promise interface.
+ * Writes or appends to an existing a file at a given path via a promise interface.
  *
  * @param {string} path
  * @param {string} fileName
@@ -35,14 +35,19 @@ export const getFile = async (path: string, encoding: BufferEncoding): Promise<s
  *
  * @return {Promise<void>}
  */
-export const createFile = async (path: string, fileName: string, data: string): Promise<void> => {
+export const appendToFile = async (path: string, fileName: string, data: string): Promise<void> => {
   if (!checkIfFileOrDirectoryExists(path)) {
     fs.mkdirSync(path)
   }
-
   const writeFile = promisify(fs.writeFile)
+  const appendFile = promisify(fs.appendFile)
 
-  return await writeFile(`${path}/${fileName}`, data, 'utf8')
+  const fullPath = `${path}/${fileName}`
+  if (checkIfFileOrDirectoryExists(fullPath)) {
+    return await appendFile(fullPath, data, 'utf8')
+  }
+
+  return await writeFile(fullPath, data, 'utf8')
 }
 
 /**

--- a/apps/api/src/common/helpers/storage.helper.ts
+++ b/apps/api/src/common/helpers/storage.helper.ts
@@ -1,0 +1,59 @@
+import fs from 'fs'
+import { promisify } from 'util'
+
+/**
+ * Check if a file exists at a given path.
+ *
+ * @param {string} path
+ *
+ * @returns {boolean}
+ */
+export const checkIfFileOrDirectoryExists = (path: string): boolean => {
+  return fs.existsSync(path)
+}
+
+/**
+ * Gets file data from a given path via a promise interface.
+ *
+ * @param {string} path
+ * @param {BufferEncoding} encoding
+ *
+ * @returns {Promise<Buffer>}
+ */
+export const getFile = async (path: string, encoding: BufferEncoding): Promise<string | Buffer> => {
+  const readFile = promisify(fs.readFile)
+
+  return encoding ? readFile(path, encoding) : readFile(path, {})
+}
+
+/**
+ * Writes a file at a given path via a promise interface.
+ *
+ * @param {string} path
+ * @param {string} fileName
+ * @param {string} data
+ *
+ * @return {Promise<void>}
+ */
+export const createFile = async (path: string, fileName: string, data: string): Promise<void> => {
+  if (!checkIfFileOrDirectoryExists(path)) {
+    fs.mkdirSync(path)
+  }
+
+  const writeFile = promisify(fs.writeFile)
+
+  return await writeFile(`${path}/${fileName}`, data, 'utf8')
+}
+
+/**
+ * Delete file at the given path via a promise interface
+ *
+ * @param {string} path
+ *
+ * @returns {Promise<void>}
+ */
+export const deleteFile = async (path: string): Promise<void> => {
+  const unlink = promisify(fs.unlink)
+
+  return await unlink(path)
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,20 +8,21 @@ import { setupSwagger } from './config/swagger.config'
 import { setupExceptions } from './config/exceptions.config'
 import { setupValidation } from './config/validation.config'
 import { setupShutdownHooks } from './config/shutdown.config'
+import { PodkrepiLogger } from './app/PodkrepiLogger'
 
 const globalPrefix = process.env.GLOBAL_PREFIX ?? 'api/v1'
 const logLevels: LogLevel[] = ['error', 'log', 'warn']
-
 async function bootstrap() {
   const isDevConfig = process.env.NODE_ENV === 'development'
+  const logger = new PodkrepiLogger(isDevConfig ? ['debug', 'verbose', ...logLevels] : logLevels)
   if (isDevConfig) {
-    Logger.warn('Running with development configuration')
+    logger.warn('Running with development configuration')
   }
 
   const app = await NestFactory.create(AppModule, {
     bodyParser: false, // Body parsing is enabled later on via middlewares
     rawBody: true,
-    logger: isDevConfig ? ['debug', 'verbose', ...logLevels] : logLevels,
+    logger,
   })
 
   app.setGlobalPrefix(globalPrefix)

--- a/apps/api/src/prisma/prisma-client-exception.filter.ts
+++ b/apps/api/src/prisma/prisma-client-exception.filter.ts
@@ -11,7 +11,7 @@ import { Response } from 'express'
  * Error codes definition for Prisma Client (Query Engine)
  * https://www.prisma.io/docs/reference/api-reference/error-reference#prisma-client-query-engine
  */
-@Catch(Prisma.PrismaClientKnownRequestError)
+@Catch(Prisma.PrismaClientKnownRequestError, Prisma.PrismaClientInitializationError)
 export class PrismaClientExceptionFilter extends BaseExceptionFilter {
   catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
     const ctx = host.switchToHttp()


### PR DESCRIPTION
Partly solves #366 
Added a` PodkrepiLogger`, extending the NestJS logger to now write to a file logs of level higher than LOG in addition to logging in the conosle. 
That was suggested by @imilchev since we couldn't debug a backend error while running in GitHub actions.

**However** I found that errors such as database connections or some unexpected crashes are not passed through the Logger which defeats the point, especially considering most of the errors in GitHub Actions are probably of that type! I still haven't found a solution and would appreciate help.