### PR TITLE
Add foreign key for campaign.company_id

### DIFF
--- a/migrations/20221204140556_add_company_id_foreign_key_for_campaign/migration.sql
+++ b/migrations/20221204140556_add_company_id_foreign_key_for_campaign/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "campaigns" ADD CONSTRAINT "campaigns_company_id_fkey" FOREIGN KEY ("company_id") REFERENCES "companies"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
Implements #374
After execution, the campaign table contains `campaigns_company_id_fkey` as constraint:
```
 constraint_catalog | constraint_schema |             constraint_name             | table_catalog | table_schema |       table_name        | constraint_type | is_deferrable | initially_deferred | enforced
 postgres           | api               | campaigns_company_id_fkey               | postgres      | api          | campaigns               | FOREIGN KEY     | NO            | NO                 | YES
```