### PR TITLE
fixed rounding when importing bank transactions with floating point

### DIFF
--- a/apps/api/src/bank-transactions-file/helpers/parser.ts
+++ b/apps/api/src/bank-transactions-file/helpers/parser.ts
@@ -19,7 +19,13 @@ export function parseBankTransactionsFile(
         ) {
           const payment = new CreateManyBankPaymentsDto()
           const paymentRef = items[item].AccountMovement[movement].NarrativeI02[0]
-          payment.amount = Number(items[item].AccountMovement[movement].Amount[0]) * 100
+          // Note: the amount is kept as cents in the database, so input from file of 10.2 is saved as 1020.
+          // Rounding is also needed because sometimes amounts get parsed as 10.19999999 which creates floating numbers,
+          // but the database expects integer
+          payment.amount =
+            Math.round(
+              (Number(items[item].AccountMovement[movement].Amount[0]) + Number.EPSILON) * 10000,
+            ) / 100
           payment.currency = items[item].AccountMovement[movement].CCY[0]
           payment.extCustomerId = items[item].AccountMovement[movement].OppositeSideAccount[0]
           payment.extPaymentIntentId = items[item].AccountMovement[movement].DocumentReference[0]


### PR DESCRIPTION
Error was reported when importing bank transaction file for a specific campaign as per: https://github.com/podkrepi-bg/frontend/issues/1136

It turned out the problem is not that the campaign is completed, but because of a single amount of 160.20 which was parsed as 160.1999999. The fix was to add rounding for the expected amount to be imported.

