### PR TITLE
fixing bank imports with floating numbers

### DIFF
--- a/apps/api/src/bank-transactions-file/helpers/parser.ts
+++ b/apps/api/src/bank-transactions-file/helpers/parser.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common'
 import { CreateManyBankPaymentsDto } from '../../donations/dto/create-many-bank-payments.dto'
+import { toMoney } from '../../common/money'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const parseString = require('xml2js').parseString
@@ -19,13 +20,7 @@ export function parseBankTransactionsFile(
         ) {
           const payment = new CreateManyBankPaymentsDto()
           const paymentRef = items[item].AccountMovement[movement].NarrativeI02[0]
-          // Note: the amount is kept as cents in the database, so input from file of 10.2 is saved as 1020.
-          // Rounding is also needed because sometimes amounts get parsed as 10.19999999 which creates floating numbers,
-          // but the database expects integer
-          payment.amount =
-            Math.round(
-              (Number(items[item].AccountMovement[movement].Amount[0]) + Number.EPSILON) * 10000,
-            ) / 100
+          payment.amount = toMoney(items[item].AccountMovement[movement].Amount[0])
           payment.currency = items[item].AccountMovement[movement].CCY[0]
           payment.extCustomerId = items[item].AccountMovement[movement].OppositeSideAccount[0]
           payment.extPaymentIntentId = items[item].AccountMovement[movement].DocumentReference[0]

--- a/apps/api/src/bank-transactions-file/helpers/parser.ts
+++ b/apps/api/src/bank-transactions-file/helpers/parser.ts
@@ -19,7 +19,13 @@ export function parseBankTransactionsFile(
         ) {
           const payment = new CreateManyBankPaymentsDto()
           const paymentRef = items[item].AccountMovement[movement].NarrativeI02[0]
-          payment.amount = Number(items[item].AccountMovement[movement].Amount[0]) * 100
+          // Note: the amount is kept as cents in the database, so input from file of 10.2 is saved as 1020.
+          // Rounding is also needed because sometimes amounts get parsed as 10.19999999 which creates floating numbers,
+          // but the database expects integer
+          payment.amount =
+            Math.round(
+              (Number(items[item].AccountMovement[movement].Amount[0]) + Number.EPSILON) * 10000,
+            ) / 100
           payment.currency = items[item].AccountMovement[movement].CCY[0]
           payment.extCustomerId = items[item].AccountMovement[movement].OppositeSideAccount[0]
           payment.extPaymentIntentId = items[item].AccountMovement[movement].DocumentReference[0]

--- a/apps/api/src/common/money.ts
+++ b/apps/api/src/common/money.ts
@@ -1,0 +1,11 @@
+/**
+ * The function corrects parsing problems like "160.2" to be parsed as float 160.1999999
+ * The internal money format is in cents, so the parsed amount is multiplied by 100.
+ * For the example of "160.2" it returns an integer of 16020
+ * @param amount from external sources
+ * @returns integer amount in cents
+ */
+export function toMoney(amount: number | string): number {
+  const value = Number(amount)
+  return Math.round((value + Number.EPSILON) * 100 * 100) / 100
+}


### PR DESCRIPTION


Error was reported when importing bank transaction file for a specific campaign as per: podkrepi-bg/frontend#1136

It turned out the problem is not that the campaign is completed, but because of a single amount of 160.20 which was parsed as 160.1999999. The fix was to add rounding for the expected amount to be imported.

- fixed rounding when importing bank transactions with floating point
- extracted: toMoney function in common file
