### PR TITLE
Upgrade typescript dependency from 4.3.5->4.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "prisma-dbml-generator": "^0.9",
     "ts-jest": "^29.0.3",
     "ts-node": "10.2.1",
-    "typescript": "4.3.5"
+    "typescript": "4.8.3"
   },
   "prisma": {
     "seed": "ts-node db/seed/index.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11110,7 +11110,7 @@ chromedriver@latest:
     ts-jest: ^29.0.3
     ts-node: 10.2.1
     tslib: 2.4.0
-    typescript: 4.3.5
+    typescript: 4.8.3
   languageName: unknown
   linkType: soft
 
@@ -13597,16 +13597,6 @@ chromedriver@latest:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.3.5":
-  version: 4.3.5
-  resolution: "typescript@npm:4.3.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: bab033b5e2b0790dd35b77fd005df976ef80b8d84fd2c6e63cc31808151875beae9216e5a315fe7068e8499905c3c354248fe83272cdfc13b7705635f0c66c97
-  languageName: node
-  linkType: hard
-
 "typescript@npm:4.8.3":
   version: 4.8.3
   resolution: "typescript@npm:4.8.3"
@@ -13614,16 +13604,6 @@ chromedriver@latest:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 8286a5edcaf3d68e65c451aa1e7150ad1cf53ee0813c07ec35b7abdfdb10f355ecaa13c6a226a694ae7a67785fd7eeebf89f845da0b4f7e4a35561ddc459aba0
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@4.3.5#~builtin<compat/typescript>":
-  version: 4.3.5
-  resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=dba6d9"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 365df18cf979c971ef9543b2acaa8694377a803f98e1804c41d0ede0b09d7046cb0cd98f2eaf3884b0fe923c01a60af1f653841bd8805c9715d5479c09a4ebe4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes version of typescript to be same as the version in the frontend repo. Also, the following [PR](https://github.com/podkrepi-bg/api/pull/387) will be unblocked, as it has been failing with a feature which is missing from the older typescript version.