### PR TITLE
Check if billing name is present during cash deposit

### DIFF
--- a/apps/api/src/bank-transactions-file/helpers/parser.ts
+++ b/apps/api/src/bank-transactions-file/helpers/parser.ts
@@ -35,7 +35,7 @@ export function parseBankTransactionsFile(
           const movementFunctionalType =
             items[item].AccountMovement[movement].MovementFunctionalType[0]
           const billingName = items[item].AccountMovement[movement].OppositeSideName[0]
-          if (isBillingNamePresent(movementFunctionalType, billingName)) {
+          if (!isBillingNameNil(movementFunctionalType, billingName)) {
             payment.billingName = billingName
           }
 
@@ -52,8 +52,17 @@ export function parseBankTransactionsFile(
   return accountMovements
 }
 
-function isBillingNamePresent(movementFunctionalType: string, billingName: string) {
-  return !(
+/**
+ * The function checks if the movementType is cash deposit and if billing name is present
+ * @param movementFunctionalType - transaction type
+ * @param billingName - name of the billing if present, otherwise a json object
+ * @returns boolean
+ **/
+function isBillingNameNil(
+  movementFunctionalType: string,
+  billingName: string | { [x: string]: unknown },
+): boolean {
+  return (
     movementFunctionalType === cashDepositBGString &&
     billingName['$'] !== undefined &&
     billingName['$']['nil']


### PR DESCRIPTION
Implements 
https://github.com/podkrepi-bg/frontend/issues/1205

Test:

I've used following xml file:
[22_11_18_TestImport.xml.txt](https://github.com/podkrepi-bg/api/files/10201806/22_11_18_TestImport.xml.txt)

I have imported following records:
```xml
    <MovementFunctionalType>Вноска на каса</MovementFunctionalType>
    <MovementType>Credit</MovementType>
    <Narrative nil="true" />
    <OppositeSideAccount>BG78CECB123123123</OppositeSideAccount>
    <OppositeSideName nil="true" />
    <PaymentDate>2022-11-18T00:00:00</PaymentDate>
    <Reason>Получен междубанков превод</Reason>
------------------------------------------------------------------------------------------------
    <MovementFunctionalType>Вноска на каса</MovementFunctionalType>
    <MovementType>Credit</MovementType>
    <Narrative nil="true" />
    <OppositeSideAccount>BG11RZBB123123123123</OppositeSideAccount>
    <OppositeSideName>Firstname Lastnameee</OppositeSideName>
    <PaymentDate>2022-11-17T00:00:00</PaymentDate>
------------------------------------------------------------------------------------------------

    <CCY>BGN</CCY>
    <MovementFunctionalType>Получен междубанков превод</MovementFunctionalType>
    <MovementType>Credit</MovementType>
    <Narrative nil="true" />
    <OppositeSideAccount>BG12FINV9150123123123</OppositeSideAccount>
    <OppositeSideName>Първо Второ Трето Име</OppositeSideName>
    <PaymentDate>2022-11-17T00:00:00</PaymentDate>
```

Billing name is not present when  OppositeSideName nil="true"  and  MovementFunctionalType  is "Вноска на каса".:
<img width="1337" alt="Screenshot 2022-12-11 at 11 39 22" src="https://user-images.githubusercontent.com/44066540/206896518-c72323b7-eb77-424f-970d-ad6212b133e1.png">
