### PR TITLE
removed company relation until the frontend starts sending proper request

### DIFF
--- a/apps/api/src/campaign/dto/create-campaign.dto.ts
+++ b/apps/api/src/campaign/dto/create-campaign.dto.ts
@@ -41,7 +41,7 @@ export class CreateCampaignDto {
   @IsOptional()
   @Expose()
   @IsUUID()
-  companyId: string
+  companyId?: string
 
   @ApiProperty()
   @IsOptional()
@@ -132,7 +132,7 @@ export class CreateCampaignDto {
       beneficiary: { connect: { id: this.beneficiaryId } },
       coordinator: { connect: { id: this.coordinatorId } },
       organizer: { connect: { id: this.organizerId } },
-      company: { connect: { id: this.companyId } },
+      // company: { connect: { id: this.companyId } }, // uncomment when this one gets fixed: https://github.com/podkrepi-bg/frontend/issues/1087
     }
   }
 }


### PR DESCRIPTION
Fixing regression: 
Create campaign functionality was not working because create-camapign endpoint was expecting a company in request. Fixed by removing the company connection.

The proper fix requires development on the frontend for sending the companyId when organizer is not a person. 

