### PR TITLE
1194 - set faker seed to 1 for consistent data

### DIFF
--- a/db/seed/index.ts
+++ b/db/seed/index.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client'
+import { faker } from '@faker-js/faker'
 
 import { citiesSeed } from './city/seed'
 import { personSeed } from './person/seed'
@@ -18,6 +19,7 @@ import { companySeed } from './company/seed'
 const prisma = new PrismaClient()
 
 async function main() {
+  faker.seed(1)
   await seedEssentialData()
   await seedDevData()
 }


### PR DESCRIPTION
Add a seed of 1 to `@faker-js` so that we have consistent data on every seed. 
Would make it easier to do e2e testing on the frontend since we can hardcode data. It might be a good idea to leave some randomness on some of the seeds though. Might catch more bugs maybe?