### PR TITLE
changed deleting of campaign to set status to deleted without actually deleting it

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -60,8 +60,9 @@ export class CampaignService {
 
   async listAllCampaigns(): Promise<AdminCampaignListItem[]> {
     const campaigns = await this.prisma.campaign.findMany({
+      where: { NOT: { state: { in: [CampaignState.deleted] } } },
       orderBy: {
-        endDate: 'asc',
+        updatedAt: 'desc',
       },
       ...AdminCampaignListItemSelect,
     })
@@ -605,7 +606,10 @@ export class CampaignService {
   }
 
   async removeCampaign(campaignId: string) {
-    return await this.prisma.campaign.delete({ where: { id: campaignId } })
+    return await this.prisma.campaign.update({
+      where: { id: campaignId },
+      data: { state: CampaignState.deleted },
+    })
   }
 
   async checkCampaignOwner(keycloakId: string, campaignId: string) {


### PR DESCRIPTION
Problem: Deleting a campaign should not be possible.
Solution: Deleting campaign now sets the state to deleted, without actually removing the record. The admin UI will not show the deleted campaigns until filtering is implemented.
