### PR TITLE
reduced logger verbosity on non-dev environment

### DIFF
--- a/apps/api/src/app/middleware/apilogger.middleware.ts
+++ b/apps/api/src/app/middleware/apilogger.middleware.ts
@@ -6,6 +6,8 @@ class ApiLoggerMiddleware implements NestMiddleware {
   private readonly logger = new Logger('HTTP')
 
   use(request: Request, response: Response, next: NextFunction) {
+    if (process.env.NODE_ENV != 'development') return
+
     response.on('finish', () => {
       const { method, originalUrl } = request
       const { statusCode, statusMessage } = response

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,18 +10,18 @@ import { setupValidation } from './config/validation.config'
 import { setupShutdownHooks } from './config/shutdown.config'
 
 const globalPrefix = process.env.GLOBAL_PREFIX ?? 'api/v1'
-const logLevels: LogLevel[] = ['error', 'log', 'warn']
+const logLevels: LogLevel[] = ['error', 'warn']
 
 async function bootstrap() {
   const isDevConfig = process.env.NODE_ENV === 'development'
   if (isDevConfig) {
-    Logger.warn('Running with development configuration')
+    Logger.debug('Running with development configuration')
   }
 
   const app = await NestFactory.create(AppModule, {
     bodyParser: false, // Body parsing is enabled later on via middlewares
     rawBody: true,
-    logger: isDevConfig ? ['debug', 'verbose', ...logLevels] : logLevels,
+    logger: isDevConfig ? ['debug', 'log', 'verbose', ...logLevels] : logLevels,
   })
 
   app.setGlobalPrefix(globalPrefix)


### PR DESCRIPTION

Logging was too verbose on staging and prod environments, so reduced now.

