### PR TITLE
Cancel Payment Intent Endpoint

### DIFF
--- a/apps/api/src/donations/donations.controller.ts
+++ b/apps/api/src/donations/donations.controller.ts
@@ -26,6 +26,7 @@ import { UpdatePaymentIntentDto } from './dto/update-payment-intent.dto'
 import { CreateStripePaymentDto } from './dto/create-stripe-payment.dto'
 import { CreatePaymentIntentDto } from './dto/create-payment-intent.dto'
 import { DonationQueryDto } from '../common/dto/donation-query-dto'
+import { CancelPaymentIntentDto } from './dto/cancel-payment-intent.dto'
 
 @ApiTags('donation')
 @Controller('donation')
@@ -180,6 +181,16 @@ export class DonationsController {
     updatePaymentIntentDto: UpdatePaymentIntentDto,
   ) {
     return this.donationsService.updatePaymentIntent(id, updatePaymentIntentDto)
+  }
+
+  @Post('payment-intent/:id/cancel')
+  @Public()
+  cancelPaymentIntent(
+    @Param('id') id: string,
+    @Body()
+    cancelPaymentIntentDto: CancelPaymentIntentDto,
+  ) {
+    return this.donationsService.cancelPaymentIntent(id, cancelPaymentIntentDto)
   }
 
   @Post('create-stripe-payment')

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -492,6 +492,7 @@ export class DonationsService {
 
   /**
    * Create a payment intent for a donation
+   * https://stripe.com/docs/api/payment_intents/create
    * @param inputDto Payment intent create params
    * @returns {Promise<Stripe.Response<Stripe.PaymentIntent>>}
    */
@@ -507,6 +508,7 @@ export class DonationsService {
 
   /**
    * Update a payment intent for a donation
+   * https://stripe.com/docs/api/payment_intents/update
    * @param inputDto Payment intent create params
    * @returns {Promise<Stripe.Response<Stripe.PaymentIntent>>}
    */
@@ -515,6 +517,19 @@ export class DonationsService {
     inputDto: Stripe.PaymentIntentUpdateParams,
   ): Promise<Stripe.Response<Stripe.PaymentIntent>> {
     return this.stripeClient.paymentIntents.update(id, inputDto)
+  }
+
+  /**
+   * Cancel a payment intent for a donation
+   * https://stripe.com/docs/api/payment_intents/cancel
+   * @param inputDto Payment intent create params
+   * @returns {Promise<Stripe.Response<Stripe.PaymentIntent>>}
+   */
+  async cancelPaymentIntent(
+    id: string,
+    inputDto: Stripe.PaymentIntentCancelParams,
+  ): Promise<Stripe.Response<Stripe.PaymentIntent>> {
+    return this.stripeClient.paymentIntents.cancel(id, inputDto)
   }
 
   /**

--- a/apps/api/src/donations/dto/cancel-payment-intent.dto.ts
+++ b/apps/api/src/donations/dto/cancel-payment-intent.dto.ts
@@ -1,0 +1,11 @@
+import Stripe from 'stripe'
+import { ApiProperty } from '@nestjs/swagger'
+import { Expose } from 'class-transformer'
+import { IsOptional } from 'class-validator'
+
+export class CancelPaymentIntentDto implements Stripe.PaymentIntentCancelParams {
+  @ApiProperty()
+  @Expose()
+  @IsOptional()
+  cancellation_reason: Stripe.PaymentIntentCancelParams.CancellationReason
+}


### PR DESCRIPTION
## Motivation and context

Adds an enpoint for cancelling Payment Requests. Needed to do cleanup on cancelled donations in the new donation flow.

### New endpoints
`@Post('payment-intent/:id/cancel')` - 

#### Body:
```
cancellation_reason: Stripe.PaymentIntentCancelParams.CancellationReason
```