### PR TITLE
New Donation Flow - Payment status bug fixes after testing

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -23,7 +23,6 @@ import { VaultService } from '../vault/vault.service'
 import { CreateCampaignDto } from './dto/create-campaign.dto'
 import { UpdateCampaignDto } from './dto/update-campaign.dto'
 import { PaymentData } from '../donations/helpers/payment-intent-helpers'
-import { getAllowedPreviousStatus } from '../donations/helpers/donation-status-updates'
 import { Prisma } from '@prisma/client'
 import { CampaignSummaryDto } from './dto/campaign-summary.dto'
 import {

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -1,4 +1,5 @@
 import {
+  Prisma,
   Campaign,
   CampaignState,
   CampaignType,
@@ -20,10 +21,10 @@ import {
 import { PersonService } from '../person/person.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { VaultService } from '../vault/vault.service'
+import { shouldAllowStatusChange } from '../donations/helpers/donation-status-updates'
+import { PaymentData } from '../donations/helpers/payment-intent-helpers'
 import { CreateCampaignDto } from './dto/create-campaign.dto'
 import { UpdateCampaignDto } from './dto/update-campaign.dto'
-import { PaymentData } from '../donations/helpers/payment-intent-helpers'
-import { Prisma } from '@prisma/client'
 import { CampaignSummaryDto } from './dto/campaign-summary.dto'
 import {
   AdminCampaignListItem,
@@ -472,7 +473,10 @@ export class CampaignService {
       return
     }
     //donation exists, so check if it is safe to update it
-    else if (donation?.status !== newDonationStatus) {
+    else if (
+      donation?.status !== newDonationStatus &&
+      shouldAllowStatusChange(donation?.status, newDonationStatus)
+    ) {
       try {
         await this.prisma.donation.update({
           where: {

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -473,10 +473,7 @@ export class CampaignService {
       return
     }
     //donation exists, so check if it is safe to update it
-    else if (
-      donation?.status !== newDonationStatus &&
-      shouldAllowStatusChange(donation?.status, newDonationStatus)
-    ) {
+    else if (shouldAllowStatusChange(donation.status, newDonationStatus)) {
       try {
         await this.prisma.donation.update({
           where: {

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -473,10 +473,7 @@ export class CampaignService {
       return
     }
     //donation exists, so check if it is safe to update it
-    else if (
-      donation?.status === newDonationStatus ||
-      donation?.status === getAllowedPreviousStatus(newDonationStatus)
-    ) {
+    else if (donation?.status !== newDonationStatus) {
       try {
         await this.prisma.donation.update({
           where: {

--- a/apps/api/src/donations/dto/update-payment-intent.dto.ts
+++ b/apps/api/src/donations/dto/update-payment-intent.dto.ts
@@ -13,4 +13,8 @@ export class UpdatePaymentIntentDto implements Stripe.PaymentIntentUpdateParams 
   @ApiProperty()
   @Expose()
   currency: Currency
+
+  @ApiProperty()
+  @Expose()
+  metadata: Stripe.MetadataParam
 }

--- a/apps/api/src/donations/helpers/donation-status-updates.ts
+++ b/apps/api/src/donations/helpers/donation-status-updates.ts
@@ -1,21 +1,50 @@
 import { DonationStatus } from '@prisma/client'
 
+const initial: DonationStatus[] = [DonationStatus.initial]
+const changeable: DonationStatus[] = [
+  DonationStatus.incomplete,
+  DonationStatus.paymentRequested,
+  DonationStatus.waiting,
+]
+const final: DonationStatus[] = [
+  DonationStatus.succeeded,
+  DonationStatus.cancelled,
+  DonationStatus.deleted,
+  DonationStatus.declined,
+  DonationStatus.invalid,
+  DonationStatus.refund,
+]
+
+function isInitial(status: DonationStatus) {
+  return initial.includes(status)
+}
+
+function isChangeable(status: DonationStatus) {
+  return changeable.includes(status)
+}
+
+function isFinal(status: DonationStatus) {
+  return final.includes(status)
+}
 /**
  * The function returns the allowed previous status that can be changed/updated by the incoming donation event
  * @param newStatus the incoming status of the payment event
  * @returns allowed previous status that can be changed by the event
  */
-export function getAllowedPreviousStatus(newStatus: DonationStatus): DonationStatus | undefined {
-  switch (newStatus) {
-    case DonationStatus.waiting: {
-      return DonationStatus.initial
-    }
-    case DonationStatus.succeeded: {
-      return DonationStatus.waiting
-    }
-    case DonationStatus.cancelled: {
-      return DonationStatus.waiting
-    }
+export function shouldAllowStatusChange(
+  oldStatus: DonationStatus,
+  newStatus: DonationStatus,
+): boolean {
+  if (isFinal(oldStatus)) {
+    return false
   }
-  return undefined
+
+  if (
+    (isFinal(newStatus) || isChangeable(newStatus)) &&
+    (isChangeable(oldStatus) || isInitial(oldStatus))
+  ) {
+    return true
+  }
+
+  return false
 }

--- a/apps/api/src/donations/helpers/donation-status-updates.ts
+++ b/apps/api/src/donations/helpers/donation-status-updates.ts
@@ -35,7 +35,7 @@ export function shouldAllowStatusChange(
   oldStatus: DonationStatus,
   newStatus: DonationStatus,
 ): boolean {
-  if (isFinal(oldStatus)) {
+  if (isFinal(oldStatus) || isInitial(newStatus)) {
     return false
   }
 
@@ -46,5 +46,5 @@ export function shouldAllowStatusChange(
     return true
   }
 
-  return false
+  throw new Error(`Unhandled donation status change from ${oldStatus} to ${newStatus}`)
 }

--- a/apps/api/src/donations/helpers/donation-status-updates.ts
+++ b/apps/api/src/donations/helpers/donation-status-updates.ts
@@ -35,6 +35,10 @@ export function shouldAllowStatusChange(
   oldStatus: DonationStatus,
   newStatus: DonationStatus,
 ): boolean {
+  if (oldStatus === newStatus) {
+    return true
+  }
+
   if (isFinal(oldStatus) || isInitial(newStatus)) {
     return false
   }


### PR DESCRIPTION
## Motivation and context
Added `metadata` param to the request for updating a payment intent to be able to attach it at the end of the donation flow

After doing some testing I saw that the status of the donation was not updated correctly. It turned out to be because of this check 
https://github.com/podkrepi-bg/api/pull/436/files#diff-88a7098916ffc30bd6ca323aa43535fbe9f8301dbc7a113af66c9b5bc8ec055bL478
https://github.com/podkrepi-bg/api/blob/a61b4997f6b93b88dc8cc0b75f2bd8c0cfe5465d/apps/api/src/donations/helpers/donation-status-updates.ts#L8
Which I can't exactly wrap my head around, it probably had something to do with how previously the stirpe session was updating the payments and the order in which it was doing it.

