### PR TITLE
Modified Prisma UniqueConstraint Error Structure returned in response

### DIFF
--- a/apps/api/src/prisma/prisma-client-exception.filter.ts
+++ b/apps/api/src/prisma/prisma-client-exception.filter.ts
@@ -57,9 +57,20 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
    */
   catchUniqueConstraint(exception: Prisma.PrismaClientKnownRequestError, response: Response) {
     const status = HttpStatus.CONFLICT
+    const targets = exception?.meta?.target as string[]
+    const message =
+      targets &&
+      targets.length &&
+      targets.map((el) => {
+        const constraints = {}
+        constraints[el] = `Unique constraint violation for field {${el}}`
+        return { property: el, children: [], constraints }
+      })
+
     response.status(status).json({
       statusCode: status,
-      message: this.cleanUpException(exception),
+      message,
+      error: this.cleanUpException(exception),
     })
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
This PR is connected to this PR on the FE [#1341](https://github.com/podkrepi-bg/frontend/pull/1341)

## Motivation and context

Handling of unique constraint violation errors was implemented on the FE, so that the users receive informative messages why the submission failed. Currently the FE expects the structure of the validation errors (that are thrown if the payload is not in the correct format) to display error messages. I re-modelled the structure of the 409 errors that Prisma throws on Unique Constraint Violation in the same way as validation errors so that the logic for extracting the error messages on the FE remains the same.

This change is required so that, the implemented error handling for unique constraint violation on the FE works




