### PR TITLE
Fixing missing payment_intent_id in checkout.session.create after stripe API upgrade

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -30,6 +30,7 @@ stripe trigger payment_intent.succeeded --override payment_intent:metadata.campa
 ```
 
 Or replay an already sent event to the test webhook like this
+
 ```shell
 stripe events resend evt_3MlHGFKApGjVGa9t0GUhYsKB
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,4 +29,9 @@ In a third shell trigger individual stripe events on demand
 stripe trigger payment_intent.succeeded --override payment_intent:metadata.campaignId=e8bf74dd-6212-4a0e-b192-56e4eb19e1f2 --override payment_intent:currency=BGN
 ```
 
+Or replay an already sent event to the test webhook like this
+```shell
+stripe events resend evt_3MlHGFKApGjVGa9t0GUhYsKB
+```
+
 Important - From the the Stripe CLI docs: Triggering some events like payment_intent.succeeded or payment_intent.canceled will also send you a payment_intent.created event for completeness.

--- a/apps/api/src/app/custom-auth.guard.ts
+++ b/apps/api/src/app/custom-auth.guard.ts
@@ -5,9 +5,19 @@ import { extractRequest } from 'nest-keycloak-connect/util'
 export class CustomAuthGuard extends AuthGuard {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const [request] = extractRequest(context)
+
+    if (!request) {
+      //As recommended by https://github.com/golevelup/nestjs/tree/master/packages/stripe#usage-with-interceptors-guards-and-filters
+      const contextType = context.getType<'http' | 'stripe_webhook'>()
+      if (contextType === 'stripe_webhook') {
+        Logger.warn('Skip AuthGuard for Stripe webhook', CustomAuthGuard.name)
+        return true
+      }
+    }
+
     // Skip auth guard for Stripe routes and pseudo requests
     if (request.url === '/api/stripe/webhook' || request.object === 'event') {
-      Logger.warn('Skip AuthGuard', CustomAuthGuard.name)
+      Logger.warn('Skip AuthGuard for Stripe', CustomAuthGuard.name)
       return true
     }
     return super.canActivate(context)

--- a/apps/api/src/bank-transactions-file/helpers/use-factory-service.ts
+++ b/apps/api/src/bank-transactions-file/helpers/use-factory-service.ts
@@ -14,8 +14,8 @@ export const useFactoryService = {
         Public(),
       ],
       stripeSecrets: {
-        connect: config.get('stripe.secretKey', '') as string,
-        account: config.get('stripe.secretKey', '') as string,
+        connect: config.get('stripe.webhookSecret', ''),
+        account: config.get('stripe.webhookSecret', ''),
       },
     },
   }),

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -32,7 +32,11 @@ import {
   CampaignListItem,
   CampaignListItemSelect,
 } from './dto/list-campaigns.dto'
-import { NotificationService, donationNotificationSelect } from '../sockets/notifications/notification.service'
+import {
+  NotificationService,
+  donationNotificationSelect,
+} from '../sockets/notifications/notification.service'
+import { DonationMetadata } from '../donations/dontation-metadata.interface'
 
 @Injectable()
 export class CampaignService {
@@ -409,6 +413,7 @@ export class CampaignService {
     campaign: Campaign,
     paymentData: PaymentData,
     newDonationStatus: DonationStatus,
+    metadata?: DonationMetadata,
   ) {
     const campaignId = campaign.id
     Logger.debug('Update donation to status: ' + newDonationStatus, {
@@ -466,7 +471,7 @@ export class CampaignService {
       )
 
       try {
-        const donation = await this.prisma.donation.create({
+        donation = await this.prisma.donation.create({
           data: {
             amount: paymentData.netAmount,
             chargedAmount: paymentData.chargedAmount,
@@ -532,6 +537,42 @@ export class CampaignService {
         and status: ${newDonationStatus} because the event comes after existing donation with status: ${donation.status}`,
       )
     }
+
+    //For successful donations we will also need to link them to user and add donation wish:
+    if (newDonationStatus === DonationStatus.succeeded) {
+      Logger.debug('metadata?.isAnonymous = ' + metadata?.isAnonymous)
+
+      if (metadata?.isAnonymous != 'true') {
+        await this.prisma.donation.update({
+          where: { id: donation.id },
+          data: {
+            person: {
+              connect: {
+                email: paymentData.billingEmail,
+              },
+            },
+          },
+        })
+      }
+
+      Logger.debug('Saving donation wish ' + metadata?.wish)
+
+      if (metadata?.wish) {
+        await this.createDonationWish(metadata.wish, donation.id, campaign.id)
+      }
+    }
+  }
+
+  async createDonationWish(message: string, donationId: string, campaignId: string) {
+    const person = await this.prisma.donation.findUnique({ where: { id: donationId } }).person()
+    await this.prisma.donationWish.create({
+      data: {
+        message: message,
+        donationId,
+        campaignId,
+        personId: person?.id,
+      },
+    })
   }
 
   async donateToCampaign(campaign: Campaign, paymentData: PaymentData) {
@@ -541,8 +582,6 @@ export class CampaignService {
       netAmount: paymentData.netAmount,
       chargedAmount: paymentData.chargedAmount,
     })
-
-    await this.updateDonationPayment(campaign, paymentData, DonationStatus.succeeded)
 
     const vault = await this.getCampaignVault(campaign.id)
     if (vault) {

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -480,7 +480,7 @@ export class CampaignService {
             extPaymentMethodId: paymentData.paymentMethodId ?? '',
             billingName: paymentData.billingName,
             billingEmail: paymentData.billingEmail,
-            person: { connect: { id: paymentData.personId } },
+            person: paymentData.personId ? { connect: { id: paymentData.personId } } : {},
           },
           select: donationNotificationSelect,
         })

--- a/apps/api/src/donations/donations.controller.spec.ts
+++ b/apps/api/src/donations/donations.controller.spec.ts
@@ -127,7 +127,9 @@ describe('DonationsController', () => {
       payment_intent_data: {
         metadata: {
           campaignId: mockSession.campaignId,
+          isAnonymous: 'true',
           personId: undefined,
+          wish: null,
         },
       },
       subscription_data: undefined,

--- a/apps/api/src/donations/dontation-metadata.interface.ts
+++ b/apps/api/src/donations/dontation-metadata.interface.ts
@@ -3,6 +3,6 @@ import Stripe from 'stripe'
 export interface DonationMetadata extends Stripe.MetadataParam {
   campaignId: string | null
   personId: string | null
+  isAnonymous: string | null
+  wish: string | null
 }
-
-

--- a/apps/api/src/donations/events/stripe-payment.service.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.ts
@@ -293,12 +293,12 @@ export class StripePaymentService {
       )
     }
 
-    const billingData = getInvoiceData(invoice)
-    await this.donateToCampaign(campaign, billingData, metadata.campaignId)
+    const paymentData = getInvoiceData(invoice)
+    await this.donateToCampaign(campaign, paymentData, metadata.campaignId)
   }
 
-  async donateToCampaign(campaign: Campaign, billingData: PaymentData, campaignId: string) {
-    await this.campaignService.donateToCampaign(campaign, billingData)
+  async donateToCampaign(campaign: Campaign, paymentData: PaymentData, campaignId: string) {
+    await this.campaignService.donateToCampaign(campaign, paymentData)
     await this.checkForCompletedCampaign(campaignId)
   }
 

--- a/apps/api/src/donations/events/stripe-payment.service.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.ts
@@ -54,15 +54,11 @@ export class StripePaymentService {
       )
     }
 
-    const billingDetails = getPaymentData(paymentIntent)
+    const paymentData = getPaymentData(paymentIntent)
     /*
      * Handle the create event
      */
-    await this.campaignService.updateDonationPayment(
-      campaign,
-      billingDetails,
-      DonationStatus.waiting,
-    )
+    await this.campaignService.updateDonationPayment(campaign, paymentData, DonationStatus.waiting)
   }
 
   @StripeWebhookHandler('payment_intent.canceled')
@@ -124,7 +120,14 @@ export class StripePaymentService {
 
     const billingData = getPaymentData(paymentIntent, charge)
 
-    await this.donateToCampaign(campaign, billingData, metadata.campaignId)
+    await this.campaignService.updateDonationPayment(
+      campaign,
+      billingData,
+      DonationStatus.succeeded,
+      metadata,
+    )
+    await this.campaignService.donateToCampaign(campaign, billingData)
+    await this.checkForCompletedCampaign(metadata.campaignId)
   }
 
   @StripeWebhookHandler('customer.subscription.created')
@@ -268,7 +271,12 @@ export class StripePaymentService {
     const invoice: Stripe.Invoice = event.data.object as Stripe.Invoice
     Logger.log('[ handleInvoicePaid ]', invoice)
 
-    let metadata: DonationMetadata = { campaignId: null, personId: null }
+    let metadata: DonationMetadata = {
+      campaignId: null,
+      personId: null,
+      isAnonymous: null,
+      wish: null,
+    }
 
     invoice.lines.data.forEach((line: Stripe.InvoiceLineItem) => {
       if (line.type === 'subscription') {
@@ -294,12 +302,14 @@ export class StripePaymentService {
     }
 
     const paymentData = getInvoiceData(invoice)
-    await this.donateToCampaign(campaign, paymentData, metadata.campaignId)
-  }
 
-  async donateToCampaign(campaign: Campaign, paymentData: PaymentData, campaignId: string) {
+    await this.campaignService.updateDonationPayment(
+      campaign,
+      paymentData,
+      DonationStatus.succeeded,
+    )
     await this.campaignService.donateToCampaign(campaign, paymentData)
-    await this.checkForCompletedCampaign(campaignId)
+    await this.checkForCompletedCampaign(metadata.campaignId)
   }
 
   //if the campaign is finished, we need to stop all active subscriptions


### PR DESCRIPTION
## Motivation and context
Additional fixes after the stripe upgrade:

- fixed: anonymous donation creation
- updated stripe testing instructions
- renaming variables for readability
- fixed: stripe not sending payment_intent_id in checkout.session.create response

Side effect: fixed donation wishes to be created only on successful donation - closes: https://github.com/podkrepi-bg/frontend/issues/1116
