### PR TITLE
Update `node` to 19 in the `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:18-alpine3.17 as base
+FROM node:19-alpine3.17 as base
 WORKDIR /app
 RUN apk add --update --no-cache openssl1.1-compat
 ARG TARGET_APP

--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.17 as base
+FROM node:19-alpine3.17 as base
 RUN apk add --update --no-cache openssl1.1-compat
 WORKDIR /app
 


### PR DESCRIPTION
## Motivation and context

Updates docker images to use `node:19`, we suspect the Stripe connection issues might have something to do with the node version. 

