### PR TITLE
#464 - Add check for an existing `person` and connect before updating `donation`

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -490,7 +490,10 @@ export class CampaignService {
             extPaymentMethodId: paymentData.paymentMethodId ?? '',
             billingName: paymentData.billingName,
             billingEmail: paymentData.billingEmail,
-            person: person ? { connect: { id: person.id } } : undefined,
+            person:
+              metadata?.isAnonymous !== 'true' && person
+                ? { connect: { id: person.id } }
+                : undefined,
           },
           select: donationNotificationSelect,
         })
@@ -520,7 +523,10 @@ export class CampaignService {
             extPaymentIntentId: paymentData.paymentIntentId,
             billingName: paymentData.billingName,
             billingEmail: paymentData.billingEmail,
-            person: person ? { connect: { id: person.id } } : undefined,
+            person:
+              metadata?.isAnonymous !== 'true' && person
+                ? { connect: { id: person.id } }
+                : undefined,
           },
           select: donationNotificationSelect,
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #464

## Motivation and context

Quick fix to check if a person exists and then connect to the donation accordingly.
This whole flow needs revisiting and will be addressed in #466 
<!--- Why is this change required? -->
<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->

## Testing

Tested out the whole flow for both logged, anonymous and not logged and it is working as expected 

