### PR TITLE
fix contact form mails

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The logic is the following:
 | `SENTRY_SERVER_ROOT_DIR`  | App directory inside the docker image        | /app                                                                        |
 | `SENDGRID_API_KEY`        | SendGrid API key                             | `""` - emails disabled if not set                                           |
 | `SENDGRID_SENDER_EMAIL`   | SendGrid sender email                        | info@podkrepi.bg                                                            |
-| `SENDGRID_INTERNAL_EMAIL` | Internal notifications email                 | info@podkrepi.bg (Prod), qa@podkrepi.bg (Staging), dev@podkrepi.bg (Dev)    |
+| `SENDGRID_INTERNAL_EMAIL` | Internal notification email from contact form request | info@podkrepi.bg (Prod), qa@podkrepi.bg (Dev), dev@podkrepi.bg (localhost)    |
 | `SENDGRID_CONTACTS_URL`   | Endpoint to receive newsletter subscriptions | /v3/marketing/contacts                                                      |
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -290,37 +290,37 @@ The logic is the following:
 
 ## Environment variables
 
-| Setting                   | Description                                  | Default value                                                               |
-| ------------------------- | -------------------------------------------- | --------------------------------------------------------------------------- |
-| `PORT`                    | The address on which the module binds.       | 5010                                                                        |
-| `GLOBAL_PREFIX`           | Registers a prefix for every HTTP route path | api/v1                                                                      |
-| `APP_VERSION`             | The version of the application               | "unknown"                                                                   |
-| `APP_ENV`                 | Application runtime environment              | development                                                                 |
-| `NODE_ENV`                | Node build environment                       | development                                                                 |
-| `TARGET_ENV`              | Docker multi-stage target                    | development                                                                 |
-| `TARGET_APP`              | Run specific application from the image.     | api                                                                         |
-| `DATABASE_URL`            | Database connection string.                  | postgres://postgres:postgrespass@localhost:5432/postgres?schema=api         |
-| `S3_ENDPOINT`             | Endpoint for S3 interface.                   | <https://cdn-dev.podkrepi.bg>                                               |
-| `S3_BUCKET`               | The S3 bucket to be used for storing files   | campaign-files                                                              |
-| `S3_ACCESS_KEY`           | The S3 access key.                           | \*\*\*\*\*\*                                                                |
-| `S3_SECRET_ACCESS_KEY`    | The S3 secret access key.                    | \*\*\*\*\*\*                                                                |
-| `KEYCLOAK_URL`            | Keycloak authentication url                  | <http://localhost:8180>                                                     |
-| `KEYCLOAK_REALM`          | Keycloak Realm name                          | webapp                                                                      |
-| `KEYCLOAK_CLIENT_ID`      | Keycloak Client name                         | jwt-headless                                                                |
-| `KEYCLOAK_SECRET`         | Secret to reach Keycloak in headless mode    | DEV-KEYCLOAK-SECRET                                                         |
-| `KEYCLOAK_USER`           | Master user for Keycloak Server              | admin                                                                       |
-| `KEYCLOAK_PASSWORD`       | Master user's password for Keycloak Server   | admin                                                                       |
-| `STRIPE_SECRET_KEY`       | Stripe secret key                            | \*\*\*\*\*\*                                                                |
-| `STRIPE_WEBHOOK_SECRET`   | Stripe webhook secret key                    | \*\*\*\*\*\*                                                                |
-| `SENTRY_DSN`              | Sentry Data Source Name                      | <https://58b71cdea21f45c0bcbe5c1b49317973@o540074.ingest.sentry.io/5707518> |
-| `SENTRY_ORG`              | Sentry organization                          | podkrepibg                                                                  |
-| `SENTRY_PROJECT`          | Sentry project                               | rest-api                                                                    |
-| `SENTRY_AUTH_TOKEN`       | Sentry build auth token                      | \*\*\*\*\*\*                                                                |
-| `SENTRY_SERVER_ROOT_DIR`  | App directory inside the docker image        | /app                                                                        |
-| `SENDGRID_API_KEY`        | SendGrid API key                             | `""` - emails disabled if not set                                           |
-| `SENDGRID_SENDER_EMAIL`   | SendGrid sender email                        | info@podkrepi.bg                                                            |
-| `SENDGRID_INTERNAL_EMAIL` | Internal notification email from contact form request | info@podkrepi.bg (Prod), qa@podkrepi.bg (Dev), dev@podkrepi.bg (localhost)    |
-| `SENDGRID_CONTACTS_URL`   | Endpoint to receive newsletter subscriptions | /v3/marketing/contacts                                                      |
+| Setting                   | Description                                           | Default value                                                               |
+| ------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| `PORT`                    | The address on which the module binds.                | 5010                                                                        |
+| `GLOBAL_PREFIX`           | Registers a prefix for every HTTP route path          | api/v1                                                                      |
+| `APP_VERSION`             | The version of the application                        | "unknown"                                                                   |
+| `APP_ENV`                 | Application runtime environment                       | development                                                                 |
+| `NODE_ENV`                | Node build environment                                | development                                                                 |
+| `TARGET_ENV`              | Docker multi-stage target                             | development                                                                 |
+| `TARGET_APP`              | Run specific application from the image.              | api                                                                         |
+| `DATABASE_URL`            | Database connection string.                           | postgres://postgres:postgrespass@localhost:5432/postgres?schema=api         |
+| `S3_ENDPOINT`             | Endpoint for S3 interface.                            | <https://cdn-dev.podkrepi.bg>                                               |
+| `S3_BUCKET`               | The S3 bucket to be used for storing files            | campaign-files                                                              |
+| `S3_ACCESS_KEY`           | The S3 access key.                                    | \*\*\*\*\*\*                                                                |
+| `S3_SECRET_ACCESS_KEY`    | The S3 secret access key.                             | \*\*\*\*\*\*                                                                |
+| `KEYCLOAK_URL`            | Keycloak authentication url                           | <http://localhost:8180>                                                     |
+| `KEYCLOAK_REALM`          | Keycloak Realm name                                   | webapp                                                                      |
+| `KEYCLOAK_CLIENT_ID`      | Keycloak Client name                                  | jwt-headless                                                                |
+| `KEYCLOAK_SECRET`         | Secret to reach Keycloak in headless mode             | DEV-KEYCLOAK-SECRET                                                         |
+| `KEYCLOAK_USER`           | Master user for Keycloak Server                       | admin                                                                       |
+| `KEYCLOAK_PASSWORD`       | Master user's password for Keycloak Server            | admin                                                                       |
+| `STRIPE_SECRET_KEY`       | Stripe secret key                                     | \*\*\*\*\*\*                                                                |
+| `STRIPE_WEBHOOK_SECRET`   | Stripe webhook secret key                             | \*\*\*\*\*\*                                                                |
+| `SENTRY_DSN`              | Sentry Data Source Name                               | <https://58b71cdea21f45c0bcbe5c1b49317973@o540074.ingest.sentry.io/5707518> |
+| `SENTRY_ORG`              | Sentry organization                                   | podkrepibg                                                                  |
+| `SENTRY_PROJECT`          | Sentry project                                        | rest-api                                                                    |
+| `SENTRY_AUTH_TOKEN`       | Sentry build auth token                               | \*\*\*\*\*\*                                                                |
+| `SENTRY_SERVER_ROOT_DIR`  | App directory inside the docker image                 | /app                                                                        |
+| `SENDGRID_API_KEY`        | SendGrid API key                                      | `""` - emails disabled if not set                                           |
+| `SENDGRID_SENDER_EMAIL`   | SendGrid sender email                                 | info@podkrepi.bg                                                            |
+| `SENDGRID_INTERNAL_EMAIL` | Internal notification email from contact form request | info@podkrepi.bg (Prod), qa@podkrepi.bg (Dev), dev@podkrepi.bg (localhost)  |
+| `SENDGRID_CONTACTS_URL`   | Endpoint to receive newsletter subscriptions          | /v3/marketing/contacts                                                      |
 
 ## Deployment
 

--- a/manifests/overlays/production/kustomization.yaml
+++ b/manifests/overlays/production/kustomization.yaml
@@ -7,12 +7,12 @@ bases:
   - ../../base
 
 patches:
-- path: manual/keycloak-config.patch.yaml
-- path: manual/deployment.patch.yaml
-- path: manual/sendgrid-config.patch.yaml
+  - path: manual/keycloak-config.patch.yaml
+  - path: manual/deployment.patch.yaml
+  - path: manual/sendgrid-config.patch.yaml
 
 images:
-- name: ghcr.io/podkrepi-bg/api
-  newTag: master
-- name: ghcr.io/podkrepi-bg/api/migrations
-  newTag: master
+  - name: ghcr.io/podkrepi-bg/api
+    newTag: master
+  - name: ghcr.io/podkrepi-bg/api/migrations
+    newTag: master

--- a/manifests/overlays/production/kustomization.yaml
+++ b/manifests/overlays/production/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 patches:
 - path: manual/keycloak-config.patch.yaml
 - path: manual/deployment.patch.yaml
+- path: manual/sendgrid-config.patch.yaml
 
 images:
 - name: ghcr.io/podkrepi-bg/api


### PR DESCRIPTION
## Motivation and context
It was reported that mails from contact form questions are going to qa@podkrepi.bg, instead of to info@podkrepi.bg.
The fix is done by adding the prod specific sendgrid overlay to automatically be applied during deployment

- added overlay for prod to send contact form mails to info@podkrepi.bg
- formatting changes only - see previous commit for config diffs


