### PR TITLE
Add donated money in Donation Wishes

### DIFF
--- a/apps/api/src/domain/generated/donation/entities/donation.entity.ts
+++ b/apps/api/src/domain/generated/donation/entities/donation.entity.ts
@@ -1,6 +1,7 @@
 import { DonationType, DonationStatus, PaymentProvider, Currency } from '@prisma/client'
 import { Person } from '../../person/entities/person.entity'
 import { Vault } from '../../vault/entities/vault.entity'
+import { DonationWish } from '../../donationWish/entities/donationWish.entity'
 
 export class Donation {
   id: string
@@ -21,4 +22,5 @@ export class Donation {
   chargedAmount: number
   person?: Person | null
   targetVault?: Vault
+  DonationWish?: DonationWish | null
 }

--- a/apps/api/src/domain/generated/donationWish/dto/create-donationWish.dto.ts
+++ b/apps/api/src/domain/generated/donationWish/dto/create-donationWish.dto.ts
@@ -1,4 +1,3 @@
 export class CreateDonationWishDto {
   message: string
-  donationId?: string
 }

--- a/apps/api/src/domain/generated/donationWish/dto/update-donationWish.dto.ts
+++ b/apps/api/src/domain/generated/donationWish/dto/update-donationWish.dto.ts
@@ -1,4 +1,3 @@
 export class UpdateDonationWishDto {
   message?: string
-  donationId?: string
 }

--- a/apps/api/src/domain/generated/donationWish/entities/donationWish.entity.ts
+++ b/apps/api/src/domain/generated/donationWish/entities/donationWish.entity.ts
@@ -1,5 +1,6 @@
 import { Campaign } from '../../campaign/entities/campaign.entity'
 import { Person } from '../../person/entities/person.entity'
+import { Donation } from '../../donation/entities/donation.entity'
 
 export class DonationWish {
   id: string
@@ -11,4 +12,5 @@ export class DonationWish {
   updatedAt: Date | null
   campaign?: Campaign
   person?: Person | null
+  donation?: Donation | null
 }

--- a/apps/api/src/donation-wish/donation-wish.service.ts
+++ b/apps/api/src/donation-wish/donation-wish.service.ts
@@ -24,7 +24,6 @@ export class DonationWishService {
     const rowCount = this.prisma.donationWish.count({ where: { campaignId } })
 
     const [items, totalCount] = await this.prisma.$transaction([donationWishes, rowCount])
-    console.log(items)
     return { items: items, totalCount: totalCount }
   }
 }

--- a/apps/api/src/donation-wish/donation-wish.service.ts
+++ b/apps/api/src/donation-wish/donation-wish.service.ts
@@ -15,11 +15,16 @@ export class DonationWishService {
       take: pageSize ? pageSize : undefined,
       where: { campaignId },
       orderBy: { createdAt: 'desc' },
-      include: { person: { select: { id: true, firstName: true, lastName: true } } },
+      include: {
+        person: { select: { id: true, firstName: true, lastName: true } },
+        donation: { select: { amount: true } },
+      },
     })
+
     const rowCount = this.prisma.donationWish.count({ where: { campaignId } })
 
     const [items, totalCount] = await this.prisma.$transaction([donationWishes, rowCount])
+    console.log(items)
     return { items: items, totalCount: totalCount }
   }
 }

--- a/migrations/20230429053842_add_donation_relation_to_donation_wishes/migration.sql
+++ b/migrations/20230429053842_add_donation_relation_to_donation_wishes/migration.sql
@@ -1,2 +1,5 @@
+-- Ensure that there are no orphaned donation wishes
+DELETE FROM "donation_wishes" WHERE "donation_id" NOT IN (SELECT "id" FROM "donations");
+
 -- AddForeignKey
 ALTER TABLE "donation_wishes" ADD CONSTRAINT "donation_wishes_donation_id_fkey" FOREIGN KEY ("donation_id") REFERENCES "donations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/migrations/20230429053842_add_donation_relation_to_donation_wishes/migration.sql
+++ b/migrations/20230429053842_add_donation_relation_to_donation_wishes/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "donation_wishes" ADD CONSTRAINT "donation_wishes_donation_id_fkey" FOREIGN KEY ("donation_id") REFERENCES "donations"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -313,6 +313,7 @@ Table donations {
   chargedAmount Int [not null, default: 0]
   person people
   targetVault vaults [not null]
+  DonationWish donation_wishes
 }
 
 Table donation_wishes {
@@ -325,6 +326,7 @@ Table donation_wishes {
   updatedAt DateTime
   campaign campaigns [not null]
   person people
+  donation donations
 }
 
 Table recurring_donations {
@@ -747,6 +749,8 @@ Ref: donations.targetVaultId > vaults.id
 Ref: donation_wishes.campaignId > campaigns.id
 
 Ref: donation_wishes.personId > people.id
+
+Ref: donation_wishes.donationId - donations.id
 
 Ref: recurring_donations.personId > people.id
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native"]
+  provider        = "prisma-client-js"
+  binaryTargets   = ["native"]
   previewFeatures = ["orderByNulls"]
 }
 
@@ -377,6 +377,7 @@ model Donation {
   chargedAmount      Int             @default(0)
   person             Person?         @relation(fields: [personId], references: [id])
   targetVault        Vault           @relation(fields: [targetVaultId], references: [id])
+  DonationWish       DonationWish?
 
   @@map("donations")
 }
@@ -391,6 +392,7 @@ model DonationWish {
   updatedAt  DateTime? @updatedAt @map("updated_at") @db.Timestamptz(6)
   campaign   Campaign  @relation(fields: [campaignId], references: [id])
   person     Person?   @relation(fields: [personId], references: [id])
+  donation   Donation? @relation(fields: [donationId], references: [id])
 
   @@map("donation_wishes")
 }
@@ -506,7 +508,7 @@ model BankTransaction {
   currency           Currency            @default(BGN)
   description        String              @db.VarChar(200)
   //Matched campaign payment code
-  matchedRef         String?             @map("matched_ref")  @db.VarChar(100)
+  matchedRef         String?             @map("matched_ref") @db.VarChar(100)
   type               BankTransactionType
   // For Bank donations, describes if campaign was recognized and donation imported
   bankDonationStatus BankDonationStatus?
@@ -529,20 +531,20 @@ model Expense {
   approvedBy   Person?       @relation(fields: [approvedById], references: [id])
   document     Document?     @relation(fields: [documentId], references: [id])
   vault        Vault         @relation(fields: [vaultId], references: [id])
-  spentAt      DateTime    @default(now()) @map("spent_at") @db.Timestamptz(6)
+  spentAt      DateTime      @default(now()) @map("spent_at") @db.Timestamptz(6)
   expenseFiles ExpenseFile[]
 
   @@map("expenses")
 }
 
 model ExpenseFile {
-  id             String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  filename       String       @db.VarChar(200)
-  mimetype       String       @db.VarChar(100)
-  expenseId      String       @map("expense_id") @db.Uuid
-  uploaderId     String       @map("uploader_id") @db.Uuid
-  expense        Expense      @relation(fields: [expenseId], references: [id])
-  uploadedBy     Person       @relation(fields: [uploaderId], references: [id])
+  id         String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  filename   String  @db.VarChar(200)
+  mimetype   String  @db.VarChar(100)
+  expenseId  String  @map("expense_id") @db.Uuid
+  uploaderId String  @map("uploader_id") @db.Uuid
+  expense    Expense @relation(fields: [expenseId], references: [id])
+  uploadedBy Person  @relation(fields: [uploaderId], references: [id])
 
   @@map("expense_files")
 }
@@ -771,7 +773,7 @@ enum BankTransactionType {
 enum BankDonationStatus {
   unrecognized
   imported
-  reImported @map("re_imported")
+  reImported   @map("re_imported")
   importFailed @map("import_failed")
 
   @@map("bank_donation_status")


### PR DESCRIPTION
Closes https://github.com/podkrepi-bg/api/issues/444
Changes:

- Added a relation to the Donation model in the Donation Wishes schema. In this way each donation wish will contain the amount of money.
- formating ( yarn prisma format)
Now the endpoint will return all donation wishes in the following format:
```

 [ {
    id: '008f857d-9f0e-47b0-a5f8-7b1b07e102f7',
    message: 'Animi quod eveniet. Saepe sunt nisi labore iste. Totam magnam facere ea. Blanditiis similique et. Minima nulla rem harum quas eius.',
    campaignId: '34af7187-acf1-45a3-b73f-ee22adb697a9',
    personId: '8ed5e8a6-74f5-42e3-9e33-24f5a8958fcc',
    donationId: '027e259b-9c6c-4ae3-ac50-023f5e5f2e17',
    createdAt: 2022-10-13T21:16:22.342Z,
    updatedAt: 2023-04-14T06:29:28.388Z,
    person: {
      id: '8ed5e8a6-74f5-42e3-9e33-24f5a8958fcc',
      firstName: 'Admin',
      lastName: 'Dev'
    },
    donation: { amount: 12686 }
  }]
```