### PR TITLE
Add the campaign id to the export of the donations

### DIFF
--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -713,6 +713,7 @@ export class DonationsService {
         ? `${donation.person.firstName} ${donation.person.lastName}`
         : 'Anonymous Donor',
       email: donation.person ? donation.person.email : '',
+      campaignId: donation.targetVault.campaign.id,
     }))
 
     const donationExcelTemplate = getTemplateByTable('donations')

--- a/apps/api/src/donations/queries/donation.validator.ts
+++ b/apps/api/src/donations/queries/donation.validator.ts
@@ -12,6 +12,11 @@ export const donationWithPerson = Prisma.validator<Prisma.DonationFindManyArgs>(
     targetVault: {
       select: {
         name: true,
+        campaign: {
+          select: {
+            id: true
+          }
+        }
       },
     },
   },

--- a/apps/api/src/export/helpers/exportableData.ts
+++ b/apps/api/src/export/helpers/exportableData.ts
@@ -66,6 +66,7 @@ const exportableData = {
           { header: 'BillingName', key: 'billingName', width: donationsDefaultCellWidth },
           { header: 'BillingEmail', key: 'billingEmail', width: donationsDefaultCellWidth },
           { header: 'Payment Provider', key: 'provider', width: donationsDefaultCellWidth },
+          { header: 'Campaign ID', key: 'campaignId', width: donationsDefaultCellWidth },
         ],
         style: {
           header: defaultHeaderStyle,


### PR DESCRIPTION
This will help with reports for the finance team.

They can see the campaign in the UI, but not in the export.