### PR TITLE
src/donations: Expand user's donations query to check for billingEmail

### DIFF
--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -422,9 +422,17 @@ export class DonationsService {
   async getUserDonationById(
     id: string,
     keycloakId: string,
+    email: string,
   ): Promise<(Donation & { person: Person | null }) | null> {
     return await this.prisma.donation.findFirst({
-      where: { id, person: { keycloakId }, status: DonationStatus.succeeded },
+      where: { 
+        id, 
+        status: DonationStatus.succeeded,
+        OR:[
+          {billingEmail: email},
+          {person: { keycloakId }}
+        ] 
+      },
       include: {
         person: {
           select: {
@@ -629,9 +637,14 @@ export class DonationsService {
     }
   }
 
-  async getDonationsByUser(keycloakId: string) {
+  async getDonationsByUser(keycloakId: string, email: string) {
     const donations = await this.prisma.donation.findMany({
-      where: { person: { keycloakId } },
+      where: {
+        OR:[
+        {billingEmail: email},  
+        {person: { keycloakId }},
+        ]
+      } ,
       orderBy: [{ createdAt: 'desc' }],
       include: {
         targetVault: {


### PR DESCRIPTION
Currently anonnymous donations are not included in user's profile. Solve this by making necessary queries look for match in either keycloakId, or billingEmail.

Note:
This solution would only work if the logged in user has, either left the email field empty, or has entered the same email as the one belonging to the account.

<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #500 

## Motivation and context

<!--- Why is this change required? -->
<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->

## Testing

### Steps to test

### New endpoints

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail what the new endpoints achieve. -->
<!--- Include links to the related pages -->
<!--- Impact of your change to other areas of the code -->

## Environment

### New environment variables:

<!-- Mark with [x] when variable is added to `.env.example`  -->

- [ ] `NEW_ENV_VAR`: env var details

### New or updated dependencies:

<!-- including dev dependencies -->

Dependency name|Previous version|Updated version|Details
---|---|---|---
`dependency/name`|`v1.0.0`|`v2.0.0`|

