### PR TITLE
Format admin notification emails

### DIFF
--- a/apps/api/src/assets/templates/expiring-iris-consent.mjml
+++ b/apps/api/src/assets/templates/expiring-iris-consent.mjml
@@ -1,5 +1,5 @@
 <mjml>
-  <mj-body background-color="#ffffff" font-size="13px">
+  <mj-body background-color="#ffffff" font-size="13px" width="90%">
     <mj-section
       background-color="#009FE3"
       vertical-align="top"
@@ -16,7 +16,7 @@
           padding-right="25px"
           padding-bottom="30px"
           padding-top="50px">
-          Засечени са неразпознати банкови дарения
+          Изтичащо съгласие за достъп до банкова информация
         </mj-text>
       </mj-column>
     </mj-section>
@@ -34,7 +34,7 @@
         <mj-text
           align="left"
           color="#ffffff"
-          font-size="15px"
+          font-size="18px"
           font-family="open Sans Helvetica, Arial, sans-serif"
           padding-left="25px"
           padding-right="25px">
@@ -47,7 +47,7 @@
         <mj-button
           background-color="#feeb35"
           font-family="Helvetica, Arial, sans-serif"
-          font-size="16px"
+          font-size="17px"
           border-radius="30px"
           color="#000000"
           padding="15px 30px"

--- a/apps/api/src/assets/templates/unrecognized-donation.mjml
+++ b/apps/api/src/assets/templates/unrecognized-donation.mjml
@@ -1,5 +1,5 @@
 <mjml>
-  <mj-body background-color="#ffffff" font-size="13px">
+  <mj-body background-color="#ffffff" font-size="13px" width="90%">
     <mj-section
       background-color="#009FE3"
       vertical-align="top"
@@ -34,7 +34,7 @@
         <mj-text
           align="left"
           color="#ffffff"
-          font-size="15px"
+          font-size="18px"
           font-family="open Sans Helvetica, Arial, sans-serif"
           padding-left="25px"
           padding-right="25px">
@@ -51,7 +51,7 @@
             font-family="open Sans Helvetica, Arial, sans-serif">
             <th style="padding: 10px" width="16%">Транз. №</th>
             <th style="padding: 10px" width="16%">Изпращач</th>
-            <th style="padding: 10px" width="16%">Сума</th>
+            <th style="padding: 10px" width="13%">Сума</th>
             <th style="padding: 10px" width="31%">Основание</th>
             <th style="padding: 10px" width="16%">Статус</th>
           </tr>
@@ -59,7 +59,7 @@
           <tr style="border-bottom: 1px solid #ffffff">
             <td style="padding: 10px">{{ id }}</td>
             <td style="padding: 10px">{{ senderName }}</td>
-            <td style="padding: 10px">{{ amount }}</td>
+            <td style="padding: 10px">{{ amount }} {{ currency }}</td>
             <td style="padding: 10px; word-break: break-word">{{ description }}</td>
             <td style="padding: 10px">{{ bankDonationStatus }}</td>
           </tr>
@@ -69,7 +69,7 @@
         <mj-button
           background-color="#feeb35"
           font-family="Helvetica, Arial, sans-serif"
-          font-size="16px"
+          font-size="17px"
           border-radius="30px"
           color="#000000"
           padding="15px 30px"

--- a/apps/api/src/tasks/bank-import/import-transactions.task.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.ts
@@ -415,6 +415,9 @@ export class IrisTasks {
     const appUrl = this.config.get<string>(stage)
     const link = `${appUrl}/admin/bank-transactions`
 
+    // Format amount
+    transactions.forEach((trx) => (trx.amount /= 100))
+
     // Prepare Email data
     const recepient = { to: [this.billingAdminEmail] }
     const mail = new UnrecognizedDonationEmailDto({


### PR DESCRIPTION
- Format the donation amount in unrecognized bank donation emails + currency
- Make the width of the emails for unrecognized donations/expiring consent bigger - so that it's easier to read
- Fix the title of the expiring bank consent email