### PR TITLE
Added endpoint to rerun bank transactions

### DIFF
--- a/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
@@ -107,6 +107,12 @@ const stripeMock = {
   checkout: { sessions: { create: jest.fn() } },
 }
 
+// Mock the IrisTask check for environment variables
+jest
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  .spyOn(IrisTasks.prototype as any, 'checkForRequiredVariables')
+  .mockImplementation(() => true)
+
 describe('BankTransactionsController', () => {
   let controller: BankTransactionsController
   let prismaService: PrismaService

--- a/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
@@ -116,6 +116,7 @@ jest
 describe('BankTransactionsController', () => {
   let controller: BankTransactionsController
   let prismaService: PrismaService
+  let irisService: IrisTasks
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -147,6 +148,7 @@ describe('BankTransactionsController', () => {
     }).compile()
 
     controller = module.get<BankTransactionsController>(BankTransactionsController)
+    irisService = module.get<IrisTasks>(IrisTasks)
 
     prismaService = prismaMock
   })
@@ -205,6 +207,18 @@ describe('BankTransactionsController', () => {
       )
 
       expect(prismaService.$transaction).toHaveBeenCalled()
+    })
+  })
+
+  describe('rerunBankSync ', () => {
+    it('should rerun bank transactions for specific dates', async () => {
+      jest.spyOn(irisService, 'importBankTransactionsTASK').mockImplementation()
+
+      await controller.rerunBankTransactionsForDate({
+        startDate: '2022-12-01',
+        endDate: '2022-12-04',
+      })
+      expect(irisService.importBankTransactionsTASK).toHaveBeenCalledTimes(4)
     })
   })
 })

--- a/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
@@ -20,6 +20,10 @@ import { ConfigService } from '@nestjs/config'
 import { CampaignService } from '../campaign/campaign.service'
 import { PersonService } from '../person/person.service'
 import { VaultService } from '../vault/vault.service'
+import { IrisTasks } from '../tasks/bank-import/import-transactions.task'
+import { SchedulerRegistry } from '@nestjs/schedule'
+import { EmailService } from '../email/email.service'
+import { TemplateService } from '../email/template.service'
 
 const bankTransactionsMock = [
   {
@@ -129,6 +133,10 @@ describe('BankTransactionsController', () => {
         CampaignService,
         VaultService,
         PersonService,
+        IrisTasks,
+        SchedulerRegistry,
+        EmailService,
+        TemplateService,
       ],
     }).compile()
 

--- a/apps/api/src/bank-transactions/bank-transactions.controller.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   NotFoundException,
   Param,
+  Post,
   Put,
   Query,
   Res,
@@ -105,6 +106,31 @@ export class BankTransactionsController {
       trxId: bankTransaction.id,
       paymentRef: campaign.paymentReference,
       status: BankDonationStatus.reImported,
+    }
+  }
+
+  /** Manually rerun bank transaction for single date */
+  @Post('/rerun-dates')
+  @Roles({
+    roles: [RealmViewSupporters.role, ViewSupporters.role],
+    mode: RoleMatchingMode.ANY,
+  })
+  async rerunBankTransactionsForDate(@Body() body: { startDate: string; endDate: string }) {
+    console.log('rerunBankTransactionsForDate startDate: ', body.startDate)
+    if (!body.startDate) throw new BadRequestException('Missing startDate in Request')
+    if (!body.endDate) throw new BadRequestException('Missing endDate in Request')
+
+    const startDate = new Date(body.startDate.split('T')[0])
+    const endDate = new Date(body.endDate.split('T')[0])
+
+    //rerun transactions iterating from startDate to endDate
+    for (
+      const dateToCheck = startDate;
+      dateToCheck <= endDate;
+      dateToCheck.setDate(dateToCheck.getDate() + 1)
+    ) {
+      console.log('Getting transactions for date: ' + dateToCheck.toISOString().split('T')[0])
+      await this.bankTransactionsService.rerunBankTransactionsForDate(dateToCheck)
     }
   }
 }

--- a/apps/api/src/bank-transactions/bank-transactions.controller.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.controller.ts
@@ -4,6 +4,7 @@ import {
   Body,
   Controller,
   Get,
+  Logger,
   NotFoundException,
   Param,
   Post,
@@ -109,14 +110,14 @@ export class BankTransactionsController {
     }
   }
 
-  /** Manually rerun bank transaction for single date */
+  /** Manually rerun bank transactions for date interval */
   @Post('/rerun-dates')
   @Roles({
     roles: [RealmViewSupporters.role, ViewSupporters.role],
     mode: RoleMatchingMode.ANY,
   })
   async rerunBankTransactionsForDate(@Body() body: { startDate: string; endDate: string }) {
-    console.log('rerunBankTransactionsForDate startDate: ', body.startDate)
+    Logger.debug('rerunBankTransactionsForDate startDate: ', body.startDate)
     if (!body.startDate) throw new BadRequestException('Missing startDate in Request')
     if (!body.endDate) throw new BadRequestException('Missing endDate in Request')
 
@@ -129,7 +130,7 @@ export class BankTransactionsController {
       dateToCheck <= endDate;
       dateToCheck.setDate(dateToCheck.getDate() + 1)
     ) {
-      console.log('Getting transactions for date: ' + dateToCheck.toISOString().split('T')[0])
+      Logger.debug('Getting transactions for date: ' + dateToCheck.toISOString().split('T')[0])
       await this.bankTransactionsService.rerunBankTransactionsForDate(dateToCheck)
     }
   }

--- a/apps/api/src/bank-transactions/bank-transactions.module.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.module.ts
@@ -1,15 +1,20 @@
 import { Module } from '@nestjs/common'
 import { CampaignModule } from '../campaign/campaign.module'
 import { DonationsModule } from '../donations/donations.module'
-import { ExportService } from '../export/export.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { BankTransactionsController } from './bank-transactions.controller'
 import { BankTransactionsService } from './bank-transactions.service'
+import { ConfigModule } from '@nestjs/config'
+import { ExportModule } from '../export/export.module'
+import { IrisTasks } from '../tasks/bank-import/import-transactions.task'
+import { HttpModule } from '@nestjs/axios'
+import { EmailService } from '../email/email.service'
+import { TemplateService } from '../email/template.service'
 
 @Module({
-  imports: [CampaignModule, DonationsModule],
+  imports: [CampaignModule, DonationsModule, ConfigModule, ExportModule, HttpModule],
   controllers: [BankTransactionsController],
-  providers: [BankTransactionsService, PrismaService, ExportService],
+  providers: [BankTransactionsService, PrismaService, IrisTasks, EmailService, TemplateService], //TODO: Create Email module to not need to import each service
   exports: [BankTransactionsService],
 })
 export class BankTransactionsModule {}

--- a/apps/api/src/bank-transactions/bank-transactions.service.spec.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.service.spec.ts
@@ -10,6 +10,10 @@ import { MockPrismaService } from '../prisma/prisma-client.mock'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { VaultService } from '../vault/vault.service'
 import { BankTransactionsService } from './bank-transactions.service'
+import { IrisTasks } from '../tasks/bank-import/import-transactions.task'
+import { SchedulerRegistry } from '@nestjs/schedule'
+import { EmailService } from '../email/email.service'
+import { TemplateService } from '../email/template.service'
 
 const stripeMock = {
   checkout: { sessions: { create: jest.fn() } },
@@ -39,6 +43,10 @@ describe('BankTransactionsService', () => {
         CampaignService,
         VaultService,
         PersonService,
+        IrisTasks,
+        SchedulerRegistry,
+        EmailService,
+        TemplateService,
       ],
     }).compile()
 

--- a/apps/api/src/bank-transactions/bank-transactions.service.spec.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.service.spec.ts
@@ -19,6 +19,12 @@ const stripeMock = {
   checkout: { sessions: { create: jest.fn() } },
 }
 
+// Mock the IrisTask check for environment variables
+jest
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  .spyOn(IrisTasks.prototype as any, 'checkForRequiredVariables')
+  .mockImplementation(() => true)
+
 describe('BankTransactionsService', () => {
   let service: BankTransactionsService
 

--- a/apps/api/src/bank-transactions/bank-transactions.service.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.service.ts
@@ -15,6 +15,7 @@ import { PrismaService } from '../prisma/prisma.service'
 import { Response } from 'express'
 import { CreateBankPaymentDto } from '../donations/dto/create-bank-payment.dto'
 import { DonationsService } from '../donations/donations.service'
+import { IrisTasks } from '../tasks/bank-import/import-transactions.task'
 
 @Injectable()
 export class BankTransactionsService {
@@ -22,6 +23,7 @@ export class BankTransactionsService {
     private prisma: PrismaService,
     private exportService: ExportService,
     private donationService: DonationsService,
+    private irisBankImport: IrisTasks,
   ) {}
 
   /**
@@ -148,5 +150,9 @@ export class BankTransactionsService {
       // Import Donation
       await this.donationService.createUpdateBankPayment(bankPayment)
     })
+  }
+
+  async rerunBankTransactionsForDate(transactionsDate: Date) {
+    this.irisBankImport.importBankTransactionsTASK(transactionsDate)
   }
 }

--- a/apps/api/src/tasks/bank-import/import-transactions.task.spec.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.spec.ts
@@ -487,7 +487,7 @@ describe('ImportTransactionsTask', () => {
       )
 
       // Run task
-      await irisTasks.importBankTransactionsTASK(DateTime.now())
+      await irisTasks.importBankTransactionsTASK(new Date())
 
       expect(prepareBankTrxSpy).not.toHaveBeenCalled()
     })

--- a/apps/api/src/tasks/bank-import/import-transactions.task.spec.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.spec.ts
@@ -266,21 +266,23 @@ describe('ImportTransactionsTask', () => {
           trx.creditDebitIndicator !== 'DEBIT',
       )
 
+      const transactionsDate = new Date()
+
       // Run task
-      await irisTasks.importBankTransactionsTASK()
+      await irisTasks.importBankTransactionsTASK(transactionsDate)
 
       // 1. Should get IRIS iban account
       expect(getIBANSpy).toHaveBeenCalled()
       // 2. Should get IBAN transactions  from IRIS
-      expect(getTrxSpy).toHaveBeenCalledWith(irisIBANAccountMock)
+      expect(getTrxSpy).toHaveBeenCalledWith(irisIBANAccountMock, transactionsDate)
       // 3. Should check if transactions are up-to-date
-      expect(checkTrxsSpy).toHaveBeenCalledWith(mockIrisTransactions)
+      expect(checkTrxsSpy).toHaveBeenCalledWith(mockIrisTransactions, transactionsDate)
       expect(prismaMock.bankTransaction.count).toHaveBeenCalledWith(
         expect.objectContaining({
           where: {
             transactionDate: {
-              gte: new Date(DateTime.now().toFormat('yyyy-MM-dd')),
-              lte: new Date(DateTime.now().toFormat('yyyy-MM-dd')),
+              gte: new Date(transactionsDate.toISOString().split('T')[0]),
+              lte: new Date(transactionsDate.toISOString().split('T')[0]),
             },
           },
         }),
@@ -446,15 +448,16 @@ describe('ImportTransactionsTask', () => {
       jest.spyOn(prismaMock, '$transaction').mockResolvedValue('SUCCESS')
       jest.spyOn(prismaMock.campaign, 'findMany').mockResolvedValue(mockDonatedCampaigns)
 
+      const transactionsDate = new Date()
       // Run task
-      await irisTasks.importBankTransactionsTASK()
+      await irisTasks.importBankTransactionsTASK(transactionsDate)
 
       // 1. Should get IRIS iban account
       expect(getIBANSpy).toHaveBeenCalled()
       // 2. Should get IBAN transactions  from IRIS
-      expect(getTrxSpy).toHaveBeenCalledWith(irisIBANAccountMock)
+      expect(getTrxSpy).toHaveBeenCalledWith(irisIBANAccountMock, transactionsDate)
       // 3. Should check if transactions are up-to-date
-      expect(checkTrxsSpy).toHaveBeenCalledWith(mockIrisTransactions)
+      expect(checkTrxsSpy).toHaveBeenCalledWith(mockIrisTransactions, transactionsDate)
       // The rest of the flow should not have been executed
       // 4. Should not be run
       expect(prepareBankTrxSpy).not.toHaveBeenCalled()
@@ -484,7 +487,7 @@ describe('ImportTransactionsTask', () => {
       )
 
       // Run task
-      await irisTasks.importBankTransactionsTASK()
+      await irisTasks.importBankTransactionsTASK(DateTime.now())
 
       expect(prepareBankTrxSpy).not.toHaveBeenCalled()
     })

--- a/apps/api/src/tasks/bank-import/import-transactions.task.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.ts
@@ -123,7 +123,7 @@ export class IrisTasks {
       return
     }
 
-    Logger.debug('RUNNING TASK - import-bank-transactions')
+    Logger.debug('RUNNING TASK - import-bank-transactions for date: ' + transactionsDate)
 
     // 1.  Get IRIS IBAN Account Info
     let ibanAccount: IrisIbanAccountInfo

--- a/apps/api/src/tasks/tasks-initializer.service.spec.ts
+++ b/apps/api/src/tasks/tasks-initializer.service.spec.ts
@@ -30,7 +30,7 @@ describe('ImportTransactionsTask', () => {
     checkout: { sessions: { create: jest.fn() } },
   }
 
-  // Mock this before instantiating service - else it failss
+  // Mock the IrisTask check for environment variables
   jest
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     .spyOn(IrisTasks.prototype as any, 'checkForRequiredVariables')

--- a/apps/api/src/tasks/tasks-initializer.service.ts
+++ b/apps/api/src/tasks/tasks-initializer.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { IrisTasks } from './bank-import/import-transactions.task'
 import { ConfigService } from '@nestjs/config'
 import { Cron, SchedulerRegistry } from '@nestjs/schedule'
+import { DateTime } from 'luxon'
 
 // Schedules all background tasks
 @Injectable()
@@ -29,7 +30,7 @@ export class TasksInitializer {
 
     const callback = async () => {
       try {
-        await this.irisTasks.importBankTransactionsTASK()
+        await this.irisTasks.importBankTransactionsTASK(new Date())
       } catch (e) {
         Logger.error('An error occured while executing importBankTransactions \n', e)
       }

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -6,9 +6,12 @@ import { IrisTasks } from './bank-import/import-transactions.task'
 import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
 import { TasksInitializer } from './tasks-initializer.service'
+import { ConfigModule } from '@nestjs/config'
+import { ScheduleModule } from '@nestjs/schedule'
 
 @Module({
-  imports: [HttpModule, DonationsModule],
+  imports: [HttpModule, DonationsModule, ConfigModule, ScheduleModule],
   providers: [IrisTasks, PrismaService, EmailService, TemplateService, TasksInitializer],
+  exports: [IrisTasks],
 })
 export class TasksModule {}


### PR DESCRIPTION
## Motivation and context

The bank integration calls may fail and certain days could be skipped.
So added endpoint to rerun bank transaction sync. 

TODO for another PR:
What remains is to add an error log in the database for days that need to be repeated automatically

