### PR TITLE
auth: Synchronize keycloak/person data on login

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -19,6 +19,7 @@ import { ProviderDto } from './dto/provider.dto'
 import { EmailService } from '../email/email.service'
 import { JwtService } from '@nestjs/jwt'
 import { TemplateService } from '../email/template.service'
+import { PrismaService } from '../prisma/prisma.service'
 
 jest.mock('@keycloak/keycloak-admin-client')
 
@@ -27,6 +28,25 @@ describe('AuthService', () => {
   let config: ConfigService
   let admin: KeycloakAdminClient
   let keycloak: KeycloakConnect.Keycloak
+
+  const person: Person = {
+    id: 'e43348aa-be33-4c12-80bf-2adfbf8736cd',
+    firstName: 'Admin',
+    lastName: 'Dev',
+    keycloakId: '123',
+    email: 'test@podkrepi.bg',
+    emailConfirmed: false,
+    phone: null,
+    company: null,
+    picture: null,
+    createdAt: new Date('2021-10-07T13:38:11.097Z'),
+    updatedAt: new Date('2021-10-07T13:38:11.097Z'),
+    newsletter: false,
+    address: null,
+    birthday: null,
+    personalNumber: null,
+    stripeCustomerId: null,
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -167,12 +187,18 @@ describe('AuthService', () => {
   })
 
   describe('login', () => {
-    const email = 'someuser@example.com'
+    const email = person.email ?? ''
+    const firstName = person.firstName ?? ''
+    const lastName = person.lastName ?? ''
     const password = 's3cret'
+    const keycloakId = person.keycloakId ?? '123'
 
-    it('should call issueGrant', async () => {
+    it('should call issueGrant - without updating person', async () => {
       const token = mockDeep<Grant>({
-        access_token: { token: 't23456' },
+        access_token: {
+          token: 't23456',
+          content: { email: email, given_name: firstName, family_name: lastName, sub: keycloakId },
+        },
       })
       const keycloakSpy = jest
         .spyOn(keycloak.grantManager, 'obtainDirectly')
@@ -180,12 +206,72 @@ describe('AuthService', () => {
       const loginDto = plainToClass(LoginDto, { email, password })
       const loginSpy = jest.spyOn(service, 'login')
       const issueGrantSpy = jest.spyOn(service, 'issueGrant')
+      const userInfoSpy = jest
+        .spyOn(keycloak.grantManager, 'userInfo')
+        .mockResolvedValue(token.access_token?.content)
+
+      prismaMock.person.findFirst.mockResolvedValue(person)
+      expect(await service.login(loginDto)).toBeObject()
+      expect(loginSpy).toHaveBeenCalledWith(loginDto)
+      expect(keycloakSpy).toHaveBeenCalledWith(email, password)
+      expect(issueGrantSpy).toHaveBeenCalledWith(email, password)
+      expect(userInfoSpy).toHaveBeenCalledWith(token.access_token?.token)
+      expect(admin.auth).not.toHaveBeenCalled()
+    })
+
+    it('should call issueGrant - with updating person due to keycloak mismatch', async () => {
+      const token = mockDeep<Grant>({
+        access_token: {
+          token: 't23456',
+          content: { email: email, given_name: firstName, family_name: lastName, sub: '1234' },
+        },
+      })
+      const keycloakSpy = jest
+        .spyOn(keycloak.grantManager, 'obtainDirectly')
+        .mockResolvedValue(token)
+      const loginDto = plainToClass(LoginDto, { email, password })
+      const loginSpy = jest.spyOn(service, 'login')
+      const issueGrantSpy = jest.spyOn(service, 'issueGrant')
+      const userInfoSpy = jest
+        .spyOn(keycloak.grantManager, 'userInfo')
+        .mockResolvedValue(token.access_token?.content)
+      const createPersonSpy = jest.spyOn(Object.getPrototypeOf(service), 'createPerson')
+
+      prismaMock.person.findFirst.mockResolvedValue(person)
+      expect(await service.login(loginDto)).toBeObject()
+      expect(loginSpy).toHaveBeenCalledWith(loginDto)
+      expect(keycloakSpy).toHaveBeenCalledWith(email, password)
+      expect(issueGrantSpy).toHaveBeenCalledWith(email, password)
+      expect(userInfoSpy).toHaveBeenCalledWith(token.access_token?.token)
+      expect(admin.auth).toHaveBeenCalled()
+      expect(createPersonSpy).toHaveBeenCalled()
+    })
+
+    it('should call issueGrant - with creating person due to not being found', async () => {
+      const token = mockDeep<Grant>({
+        access_token: {
+          token: 't23456',
+          content: { email: email, given_name: firstName, family_name: lastName, sub: '1234' },
+        },
+      })
+      const keycloakSpy = jest
+        .spyOn(keycloak.grantManager, 'obtainDirectly')
+        .mockResolvedValue(token)
+      const loginDto = plainToClass(LoginDto, { email, password })
+      const loginSpy = jest.spyOn(service, 'login')
+      const issueGrantSpy = jest.spyOn(service, 'issueGrant')
+      const userInfoSpy = jest
+        .spyOn(keycloak.grantManager, 'userInfo')
+        .mockResolvedValue(token.access_token?.content)
+      const createPersonSpy = jest.spyOn(Object.getPrototypeOf(service), 'createPerson')
 
       expect(await service.login(loginDto)).toBeObject()
       expect(loginSpy).toHaveBeenCalledWith(loginDto)
       expect(keycloakSpy).toHaveBeenCalledWith(email, password)
       expect(issueGrantSpy).toHaveBeenCalledWith(email, password)
-      expect(admin.auth).not.toHaveBeenCalled()
+      expect(userInfoSpy).toHaveBeenCalledWith(token.access_token?.token)
+      expect(admin.auth).toHaveBeenCalled()
+      expect(createPersonSpy).toHaveBeenCalled()
     })
 
     it('should handle bad password on login', async () => {
@@ -223,24 +309,7 @@ describe('AuthService', () => {
       const registerDto = plainToClass(RegisterDto, { email, password, firstName, lastName })
       const createUserSpy = jest.spyOn(service, 'createUser')
       const adminSpy = jest.spyOn(admin.users, 'create').mockResolvedValue({ id: keycloakId })
-      const person: Person = {
-        id: 'e43348aa-be33-4c12-80bf-2adfbf8736cd',
-        firstName,
-        lastName,
-        keycloakId,
-        email,
-        emailConfirmed: false,
-        phone: null,
-        company: null,
-        picture: null,
-        createdAt: new Date('2021-10-07T13:38:11.097Z'),
-        updatedAt: new Date('2021-10-07T13:38:11.097Z'),
-        newsletter: false,
-        address: null,
-        birthday: null,
-        personalNumber: null,
-        stripeCustomerId: null,
-      }
+
       const prismaSpy = jest.spyOn(prismaMock.person, 'upsert').mockResolvedValue(person)
 
       expect(await service.createUser(registerDto)).toBe(person)

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -210,7 +210,7 @@ describe('AuthService', () => {
         .spyOn(keycloak.grantManager, 'userInfo')
         .mockResolvedValue(token.access_token?.content)
 
-      prismaMock.person.findFirst.mockResolvedValue(person)
+      prismaMock.person.findUnique.mockResolvedValue(person)
       expect(await service.login(loginDto)).toBeObject()
       expect(loginSpy).toHaveBeenCalledWith(loginDto)
       expect(keycloakSpy).toHaveBeenCalledWith(email, password)
@@ -237,7 +237,7 @@ describe('AuthService', () => {
         .mockResolvedValue(token.access_token?.content)
       const createPersonSpy = jest.spyOn(Object.getPrototypeOf(service), 'createPerson')
 
-      prismaMock.person.findFirst.mockResolvedValue(person)
+      prismaMock.person.findUnique.mockResolvedValue(person)
       expect(await service.login(loginDto)).toBeObject()
       expect(loginSpy).toHaveBeenCalledWith(loginDto)
       expect(keycloakSpy).toHaveBeenCalledWith(email, password)

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -148,7 +148,7 @@ export class AuthService {
       const user = await this.keycloak.grantManager.userInfo<string, KeycloakTokenParsed>(
         grant.access_token.token as string,
       )
-      const person = await this.prismaService.person.findFirst({ where: { email: user.email } })
+      const person = await this.prismaService.person.findUnique({ where: { email: user.email } })
       if (!person || person.keycloakId !== user.sub) {
         Logger.warn('No person found for the current keycloak user. Creating new one...')
         await this.authenticateAdmin()

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -145,6 +145,22 @@ export class AuthService {
       if (!grant.access_token?.token) {
         throw new InternalServerErrorException('CannotIssueTokenError')
       }
+      const user = await this.keycloak.grantManager.userInfo<string, KeycloakTokenParsed>(
+        grant.access_token.token as string,
+      )
+      const person = await this.prismaService.person.findFirst({ where: { email: user.email } })
+      if (!person || person.keycloakId !== user.sub) {
+        Logger.warn('No person found for the current keycloak user. Creating new one...')
+        await this.authenticateAdmin()
+        const userData = await this.admin.users.findOne({ id: user.sub })
+        const registerDto: RegisterDto = {
+          email: userData?.email ?? '',
+          password: '',
+          firstName: userData?.firstName ?? '',
+          lastName: userData?.lastName ?? '',
+        }
+        await this.createPerson(registerDto, user.sub)
+      }
       return {
         refreshToken: grant.refresh_token?.token,
         accessToken: grant.access_token.token,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A slight doubt exists, that in some rare occasions, there is a mismatch between the data saved in the keycloak server, and the one saved in the Person table. This mismatch could cause some unexpected behavior and unpleasant user experience, as we use the keycloakId of the logged user, for a lot of queries.
The proposed solution makes it so on every login, we check if the  email saved in the keycloak server exists in the Person table as well. 
The person record is updated on the following use cases:
1. Person record not found. In that case a new Person is being created during the login phase.
2. Person is found, but the keycloakIds are different. In that case the person record is being updated with the keycloakId coming from the keycloak server.

## Testing

### Steps to test
#### No user found use case
1. Run `yarn studio` go to Person, and delete the record, which contains the data for the authenticated user.
2. Login.
3. Go back to Prisma studio, and refresh the Person table. A new person record should be created containing the data for the authenticated user(email, firstName, lastName, keycloakId).
4. Compare the keycloakId from person record, with the one from the keycloak server to see if they match.

#### Keycloak mismatch use case
1.  Run `yarn studio` go to Person, find the Person record which contains the data for the authenticated user. Go to `keycloakId` field and edit it at random.
2. Login
3. Go back to Prisma studio, and refresh the Person table. Find the record of the authenticated user, go to `keycloakId` field, and check if it has been updated.
4. Compare the keycloakId from person record, with the one from the keycloak server to see if they match.



