### PR TITLE
Remove the global cache interceptor. 

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -148,11 +148,6 @@ import { CampaignNewsFileModule } from '../campaign-news-file/campaign-news-file
      * specified role passed.
      */
     { provide: APP_GUARD, useClass: RoleGuard },
-    /**
-     * Enables cache interceptors globally
-     * https://docs.nestjs.com/techniques/caching
-     */
-    { provide: APP_INTERCEPTOR, useClass: CacheInterceptor },
   ],
 })
 export class AppModule implements NestModule {


### PR DESCRIPTION
Using a global API interceptor is crazy.
I thought that this code simply enables the use of the cache-manager and we need to mark the API with @UseInterceptors(CacheInterceptor)

But as stated here we can force caching for ALL get apis with it:
https://docs.nestjs.com/techniques/caching#auto-caching-responses

It is much safer to enable caching PER API.
