### PR TITLE
src/donations: Order public donations by updatedAt field

### DIFF
--- a/apps/api/src/donations/donations.controller.spec.ts
+++ b/apps/api/src/donations/donations.controller.spec.ts
@@ -207,6 +207,7 @@ describe('DonationsController', () => {
       data: {
         status: existingDonation.status,
         personId: '2',
+        updatedAt: existingDonation.updatedAt,
       },
     })
     expect(vaultMock.incrementVaultAmount).toHaveBeenCalledTimes(0)
@@ -257,6 +258,7 @@ describe('DonationsController', () => {
         status: DonationStatus.succeeded,
         personId: updatePaymentDto.targetPersonId,
         billingEmail: updatePaymentDto.billingEmail,
+        updatedAt: expectedUpdatedDonation.updatedAt,
       },
     })
     expect(vaultMock.incrementVaultAmount).toHaveBeenCalledWith(

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -605,7 +605,9 @@ export class DonationsService {
         data: {
           status: status,
           personId:  updatePaymentDto.targetPersonId ? donorId : undefined,
-          billingEmail: updatePaymentDto.billingEmail ? billingEmail : undefined 
+          billingEmail: updatePaymentDto.billingEmail ? billingEmail : undefined,
+          //In case of personId or billingEmail change, take the last updatedAt property to prevent any changes to updatedAt property
+          updatedAt: updatePaymentDto.targetPersonId || updatePaymentDto.billingEmail ? currentDonation.updatedAt : undefined
         },
       })
 

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -288,7 +288,7 @@ export class DonationsService {
   ): Promise<ListDonationsDto<DonationBaseDto>> {
     const data = await this.prisma.donation.findMany({
       where: { status, targetVault: { campaign: { id: campaignId } } },
-      orderBy: [{ createdAt: 'desc' }],
+      orderBy: [{ updatedAt: 'desc' }],
       select: {
         id: true,
         type: true,

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -579,16 +579,13 @@ export class DonationsService {
       let donorId = currentDonation.personId
       let billingEmail = ''
       if (
-        updatePaymentDto.targetPersonId &&
-        currentDonation.personId !== updatePaymentDto.targetPersonId || 
+        (updatePaymentDto.targetPersonId &&
+          currentDonation.personId !== updatePaymentDto.targetPersonId) ||
         updatePaymentDto.billingEmail
       ) {
         const targetDonor = await this.prisma.person.findFirst({
           where: {
-             OR: [
-              {id: updatePaymentDto.targetPersonId },
-              {email: updatePaymentDto.billingEmail}
-            ]
+            OR: [{ id: updatePaymentDto.targetPersonId }, { email: updatePaymentDto.billingEmail }],
           },
         })
         if (!targetDonor) {
@@ -604,10 +601,13 @@ export class DonationsService {
         where: { id },
         data: {
           status: status,
-          personId:  updatePaymentDto.targetPersonId ? donorId : undefined,
+          personId: updatePaymentDto.targetPersonId ? donorId : undefined,
           billingEmail: updatePaymentDto.billingEmail ? billingEmail : undefined,
           //In case of personId or billingEmail change, take the last updatedAt property to prevent any changes to updatedAt property
-          updatedAt: updatePaymentDto.targetPersonId || updatePaymentDto.billingEmail ? currentDonation.updatedAt : undefined
+          updatedAt:
+            updatePaymentDto.targetPersonId || updatePaymentDto.billingEmail
+              ? currentDonation.updatedAt
+              : undefined,
         },
       })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When automatically importing bank transfers they are all created at the same time. As we currently order public donations by createdAt field, and the query is ran on every page change, this may cause unexpected behavior such as repeating of some bank donations in different pages, or some donations not being shown.
Instead use the updatedAt property which represents the exact time, donation record was added to database, or the last time its status has been updated. This should give us good approximation time of the donation itself.

Closes Reported in discord

## Motivation and context
Fixes a bug

## Testing

### Steps to test
#### Donations orderBy:
1. Call the endpoint responsible for listing donations:
`API_URL/api/v1/donation/listPublic/?campaignId=campaignId` where campaignId, is the id of the campaign in local enviroment.
2. Public donations should be ordered by their updatedAt property

#### updateAt change on personId/billingEmail change
1. Go to admin panel->Donations, Click F12 go to Network, and find the API response for the listed donations. Expand the first record and see its updatedAt property
2. Change donor field of the first record, of listed donations.  The updatedAt property of the first record, should be the same as in the previous API response.
3. Repeat the same for the billingEmail field

