### PR TITLE
User notifications - Part 1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,7 @@ SENDGRID_API_KEY=sendgrid-key
 SENDGRID_SENDER_EMAIL=info@podkrepi.bg
 SENDGRID_INTERNAL_EMAIL=dev@podkrepi.bg
 SENDGRID_CONTACTS_URL=/v3/marketing/contacts
+MARKETING_LIST_ID=6add1a52-f74e-4c14-af56-ec7e1d2318f0
 
 ## Stripe ##
 ############

--- a/apps/api/src/account/account.controller.spec.ts
+++ b/apps/api/src/account/account.controller.spec.ts
@@ -13,6 +13,7 @@ import KeycloakConnect from 'keycloak-connect'
 import { mock, mockDeep } from 'jest-mock-extended'
 import { JwtService } from '@nestjs/jwt'
 import { EmailService } from '../email/email.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('AccountController', () => {
   let controller: AccountController
@@ -28,6 +29,7 @@ describe('AccountController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [MarketingNotificationsModule],
       controllers: [AccountController],
       providers: [
         AccountService,

--- a/apps/api/src/account/account.controller.ts
+++ b/apps/api/src/account/account.controller.ts
@@ -8,7 +8,7 @@ import { Person } from '../domain/generated/person/entities'
 import { UpdatePersonDto } from '../person/dto/update-person.dto'
 import { PersonService } from '../person/person.service'
 import { AccountService } from './account.service'
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger'
 
 @Controller('account')
 @ApiTags('account')

--- a/apps/api/src/account/account.service.spec.ts
+++ b/apps/api/src/account/account.service.spec.ts
@@ -12,11 +12,14 @@ import { PersonService } from '../person/person.service'
 import { MockPrismaService } from '../prisma/prisma-client.mock'
 import { AccountService } from './account.service'
 
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
+
 describe('AccountService', () => {
   let service: AccountService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [MarketingNotificationsModule],
       providers: [
         AccountService,
         PersonService,

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { ProviderLoginController } from './provider-login.controller'
 import { JwtModule, JwtService } from '@nestjs/jwt'
 import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 @Module({
   controllers: [LoginController, RegisterController, RefreshController, ProviderLoginController],
@@ -25,6 +26,7 @@ import { TemplateService } from '../email/template.service'
       useExisting: KeycloakConfigService,
       imports: [AppConfigModule],
     }),
+    MarketingNotificationsModule,
   ],
   exports: [AuthService],
 })

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -30,6 +30,8 @@ import { JwtService } from '@nestjs/jwt'
 import { EmailService } from '../email/email.service'
 import { ForgottenPasswordMailDto } from '../email/template.interface'
 import { NewPasswordDto } from './dto/recovery-password.dto'
+import { NotificationsInterface } from '../notifications/notifications.interface'
+import { SendGridParams } from '../notifications/notifications.sendgrid.types'
 
 type ErrorResponse = { error: string; data: unknown }
 type KeycloakErrorResponse = { error: string; error_description: string }
@@ -60,6 +62,7 @@ export class AuthService {
     private jwtService: JwtService,
     private sendEmail: EmailService,
     @Inject(KEYCLOAK_INSTANCE) private keycloak: KeycloakConnect.Keycloak,
+    private readonly marketingNotificationsService: NotificationsInterface<SendGridParams>,
   ) {}
 
   async issueGrant(email: string, password: string): Promise<KeycloakConnect.Grant> {
@@ -160,12 +163,13 @@ export class AuthService {
   }
 
   async createUser(registerDto: RegisterDto): Promise<Person | ErrorResponse> {
+    let person: Person
     try {
       await this.authenticateAdmin()
       // Create user in Keycloak
       const user = await this.createKeycloakUser(registerDto, false)
       // Insert or connect person in app db
-      return await this.createPerson(registerDto, user.id)
+      person = await this.createPerson(registerDto, user.id)
     } catch (error) {
       const response = {
         error: error.message,
@@ -174,6 +178,28 @@ export class AuthService {
       Logger.error(response)
       return response
     }
+
+    // Add to marketing platform
+    if (registerDto.newsletter)
+      try {
+        // Add email to general marketing notifications list
+        const mainList = this.config.get('sendgrid.marketingListId')
+        if (mainList)
+          await this.marketingNotificationsService.addContactsToList({
+            contacts: [
+              {
+                email: person.email,
+                first_name: person?.firstName || '',
+                last_name: person?.lastName || '',
+              },
+            ],
+            list_ids: [mainList],
+          })
+      } catch (e) {
+        Logger.error('Failed to subscribe email', e)
+      }
+
+    return person
   }
 
   private async authenticateAdmin() {
@@ -228,6 +254,7 @@ export class AuthService {
         email: registerDto.email,
         firstName: registerDto.firstName,
         lastName: registerDto.lastName,
+        newsletter: registerDto.newsletter ? registerDto.newsletter : false,
       },
       // Store keycloakId to the person with same email
       update: { keycloakId },

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger'
 import { Expose } from 'class-transformer'
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator'
+import { IsBoolean, IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 
 export class RegisterDto {
   @ApiProperty()
@@ -26,4 +26,10 @@ export class RegisterDto {
   @IsNotEmpty()
   @IsString()
   public readonly lastName: string
+
+  @ApiProperty()
+  @Expose()
+  @IsOptional()
+  @IsBoolean()
+  public readonly newsletter?: boolean
 }

--- a/apps/api/src/auth/register.controller.ts
+++ b/apps/api/src/auth/register.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Post } from '@nestjs/common'
 import { Public, Resource, Scopes } from 'nest-keycloak-connect'
 import { AuthService } from './auth.service'
 import { RegisterDto } from './dto/register.dto'
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger'
 
 @ApiTags('register')
 @Controller('register')

--- a/apps/api/src/bank-transactions-file/bank-transactions-file.controller.spec.ts
+++ b/apps/api/src/bank-transactions-file/bank-transactions-file.controller.spec.ts
@@ -11,6 +11,7 @@ import { NotificationModule } from '../sockets/notifications/notification.module
 import { VaultService } from '../vault/vault.service'
 import { BankTransactionsFileController } from './bank-transactions-file.controller'
 import { BankTransactionsFileService } from './bank-transactions-file.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('BankTransactionsFileController', () => {
   let controller: BankTransactionsFileController
@@ -19,7 +20,7 @@ describe('BankTransactionsFileController', () => {
   }
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [NotificationModule],
+      imports: [NotificationModule, MarketingNotificationsModule],
       controllers: [BankTransactionsFileController],
       providers: [
         {

--- a/apps/api/src/bank-transactions-file/bank-transactions-file.module.ts
+++ b/apps/api/src/bank-transactions-file/bank-transactions-file.module.ts
@@ -12,6 +12,7 @@ import { StripeModule } from '@golevelup/nestjs-stripe'
 import { StripeConfigFactory } from '../donations/helpers/stripe-config-factory'
 import { ExportService } from '../export/export.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { NotificationModule } from '../sockets/notifications/notification.module
       useFactory: StripeConfigFactory.useFactory,
     }),
     NotificationModule,
+    MarketingNotificationsModule,
   ],
   controllers: [BankTransactionsFileController],
   providers: [

--- a/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.controller.spec.ts
@@ -24,6 +24,7 @@ import { IrisTasks } from '../tasks/bank-import/import-transactions.task'
 import { SchedulerRegistry } from '@nestjs/schedule'
 import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 const bankTransactionsMock = [
   {
@@ -121,7 +122,7 @@ describe('BankTransactionsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [BankTransactionsController],
-      imports: [HttpModule, NotificationModule],
+      imports: [HttpModule, NotificationModule, MarketingNotificationsModule],
       providers: [
         BankTransactionsService,
         MockPrismaService,

--- a/apps/api/src/bank-transactions/bank-transactions.service.spec.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.service.spec.ts
@@ -14,6 +14,7 @@ import { IrisTasks } from '../tasks/bank-import/import-transactions.task'
 import { SchedulerRegistry } from '@nestjs/schedule'
 import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 const stripeMock = {
   checkout: { sessions: { create: jest.fn() } },
@@ -30,7 +31,7 @@ describe('BankTransactionsService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [HttpModule, NotificationModule],
+      imports: [HttpModule, NotificationModule, MarketingNotificationsModule],
       providers: [
         BankTransactionsService,
         MockPrismaService,

--- a/apps/api/src/campaign-file/campaign-file.module.ts
+++ b/apps/api/src/campaign-file/campaign-file.module.ts
@@ -7,9 +7,10 @@ import { PersonService } from '../person/person.service'
 import { CampaignService } from '../campaign/campaign.service'
 import { VaultService } from '../vault/vault.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 @Module({
-  imports: [NotificationModule],
+  imports: [NotificationModule, MarketingNotificationsModule],
 
   controllers: [CampaignFileController],
   providers: [

--- a/apps/api/src/campaign/campaign.controller.ts
+++ b/apps/api/src/campaign/campaign.controller.ts
@@ -29,6 +29,10 @@ import { ApiQuery } from '@nestjs/swagger'
 import { DonationQueryDto } from '../common/dto/donation-query-dto'
 import { ApiTags } from '@nestjs/swagger'
 import { CampaignNewsService } from '../campaign-news/campaign-news.service'
+import { NotificationsInterface } from '../notifications/notifications.interface'
+import { CampaignSubscribeDto } from './dto/campaign-subscribe.dto'
+import { SendGridParams } from '../notifications/notifications.sendgrid.types'
+import { ConfigService } from '@nestjs/config'
 
 @ApiTags('campaign')
 @Controller('campaign')
@@ -37,6 +41,8 @@ export class CampaignController {
     private readonly campaignService: CampaignService,
     private readonly campaignNewsService: CampaignNewsService,
     @Inject(forwardRef(() => PersonService)) private readonly personService: PersonService,
+    private readonly marketingNotificationsService: NotificationsInterface<SendGridParams>,
+    private readonly config: ConfigService,
   ) {}
 
   @Get('list')
@@ -80,7 +86,7 @@ export class CampaignController {
   @Get(':slug/can-edit')
   async canEditCampaign(
     @Param('slug') slug: string,
-    @AuthenticatedUser() user: KeycloakTokenParsed
+    @AuthenticatedUser() user: KeycloakTokenParsed,
   ): Promise<boolean> {
     const campaign = await this.campaignService.isUserCampaign(user.sub, slug)
     return campaign
@@ -165,6 +171,83 @@ export class CampaignController {
       throw new ForbiddenException(
         'The user is not coordinator,organizer or beneficiery to the requested campaign',
       )
+  }
+
+  @Post(':id/subscribe')
+  @Public()
+  async subscribeToCampaignNotifications(
+    @Param('id') id: string,
+    @Body() data: CampaignSubscribeDto,
+  ) {
+    if (data.consent === false)
+      throw new BadRequestException('Notification consent should be provided')
+
+    // Check if campaign exists
+    let campaign: Awaited<ReturnType<CampaignService['getCampaignByIdWithPersonIds']>>
+    try {
+      campaign = await this.campaignService.getCampaignByIdWithPersonIds(id)
+    } catch (e) {
+      Logger.error(e)
+      throw new BadRequestException('Failed to get campaign info')
+    }
+
+    if (!campaign) throw new NotFoundException('Campaign not found')
+
+    if (campaign.state !== CampaignState.active) throw new BadRequestException('Campaign inactive')
+
+    // Check if user is registered
+    const registered = await this.personService.findByEmail(data.email)
+
+    const contact: SendGridParams['ContactData'] = {
+      email: data.email,
+      first_name: registered?.firstName || '',
+      last_name: registered?.lastName || '',
+    }
+
+    const listIds: string[] = []
+
+    // Check if the campaign has a notification list
+    if (!campaign.notificationLists?.length) {
+      const campaignList = await this.campaignService.createCampaignNotificationList(campaign)
+      // Add email to this campaign's notification list
+      listIds.push(campaignList)
+    } else {
+      listIds.push(campaign.notificationLists[0].id)
+    }
+
+    // Add email to general marketing notifications list
+    const mainList = this.config.get('sendgrid.marketingListId')
+    mainList && listIds.push(mainList)
+
+    // Add to marketing platform
+    try {
+      await this.marketingNotificationsService.addContactsToList({
+        contacts: [contact],
+        list_ids: listIds,
+      })
+    } catch (e) {
+      Logger.error('Failed to subscribe email', e)
+      throw new BadRequestException('Failed to subscribe email')
+    }
+
+    // If no prior consent has been given by a registered user
+    if (registered && !registered.newsletter)
+      try {
+        await this.personService.update(registered.id, { newsletter: true })
+      } catch (e) {
+        Logger.error('Failed to update user consent', e)
+        throw new BadRequestException('Failed to update user consent')
+      }
+    // If the email is not registered - create/update a saparate notification consent record
+    else if (!registered)
+      try {
+        await this.personService.upsertUnregisteredNotificationConsent(data.email, data.consent)
+      } catch (e) {
+        Logger.error('Failed to save unregistered consent', e)
+        throw new BadRequestException('Failed to save consent')
+      }
+
+    return { email: data.email, subscribed: true }
   }
 
   @Delete(':id')

--- a/apps/api/src/campaign/campaign.module.ts
+++ b/apps/api/src/campaign/campaign.module.ts
@@ -9,12 +9,17 @@ import { CampaignController } from './campaign.controller'
 import { CampaignService } from './campaign.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { CampaignNewsModule } from '../campaign-news/campaign-news.module'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 @Module({
-  imports: [forwardRef(() => VaultModule), NotificationModule, CampaignNewsModule],
+  imports: [
+    forwardRef(() => VaultModule),
+    MarketingNotificationsModule,
+    NotificationModule,
+    CampaignNewsModule,
+  ],
 
   controllers: [CampaignController, CampaignTypeController],
   providers: [CampaignService, PrismaService, VaultService, PersonService, ConfigService],
-
 
   exports: [CampaignService],
 })

--- a/apps/api/src/campaign/campaign.service.spec.ts
+++ b/apps/api/src/campaign/campaign.service.spec.ts
@@ -1,25 +1,184 @@
 import { ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import { PersonService } from '../person/person.service'
-import { MockPrismaService } from '../prisma/prisma-client.mock'
+import { MockPrismaService, prismaMock } from '../prisma/prisma-client.mock'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { VaultModule } from '../vault/vault.module'
 import { VaultService } from '../vault/vault.service'
 import { CampaignService } from './campaign.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
+import { CampaignState, Currency } from '@prisma/client'
+import { CreateCampaignDto } from './dto/create-campaign.dto'
+import { UpdateCampaignDto } from './dto/update-campaign.dto'
+import { NotificationsInterface } from '../notifications/notifications.interface'
 
 describe('CampaignService', () => {
   let service: CampaignService
+  let marketing: NotificationsInterface<any>
+
+  const mockCreateCampaign = {
+    slug: 'test-slug',
+    title: 'Test name',
+    description: 'Test description',
+    essence: 'test',
+    coordinatorId: 'testCoordinatorId',
+    beneficiaryId: 'testBeneficiaryId',
+    organizerId: 'testOrganizerId',
+    companyId: 'testCompanyId',
+    campaignTypeId: 'testCampaignTypeId',
+    targetAmount: 1000,
+    reachedAmount: 0,
+    startDate: null,
+    endDate: null,
+    currency: Currency.BGN,
+    toEntity: new CreateCampaignDto().toEntity,
+  } as CreateCampaignDto
+
+  const paymentReferenceMock = 'NY5P-KVO4-DNBZ'
+  const mockCampaign = {
+    ...mockCreateCampaign,
+    ...{
+      id: 'testId',
+      state: CampaignState.draft,
+      createdAt: new Date('2022-04-08T06:36:33.661Z'),
+      updatedAt: new Date('2022-04-08T06:36:33.662Z'),
+      deletedAt: null,
+      approvedById: null,
+      beneficiary: { person: { keycloakId: 'some-id' } },
+      coordinator: { person: { keycloakId: 'some-id' } },
+      organizer: { person: { keycloakId: 'some-id' } },
+      campaignFiles: [],
+      paymentReference: paymentReferenceMock,
+      vaults: [],
+      notificationLists: [],
+    },
+  }
+
+  const mockUpdateCampaign = {
+    ...mockCreateCampaign,
+    ...{
+      id: 'testId',
+      state: CampaignState.approved,
+      createdAt: new Date('2022-04-08T06:36:33.661Z'),
+      updatedAt: new Date('2022-04-08T06:36:33.662Z'),
+      deletedAt: null,
+      approvedById: null,
+      beneficiary: { person: { keycloakId: 'testBeneficiaryKeycloakId' } },
+      coordinator: { person: { keycloakId: 'testCoordinatorKeycloakId' } },
+      organizer: { person: { keycloakId: 'testOrganizerKeycloakId' } },
+      company: { person: { keycloakId: 'testCompanyKeycloakId' } },
+      campaignFiles: [],
+      paymentReference: paymentReferenceMock,
+      vaults: [],
+    },
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [VaultModule, NotificationModule],
-      providers: [CampaignService, MockPrismaService, VaultService, PersonService, ConfigService],
+      imports: [NotificationModule, MarketingNotificationsModule],
+      providers: [
+        VaultService,
+        CampaignService,
+        MockPrismaService,
+        VaultService,
+        PersonService,
+        ConfigService,
+      ],
     }).compile()
 
     service = module.get<CampaignService>(CampaignService)
+    marketing = module.get<NotificationsInterface<any>>(NotificationsInterface)
   })
 
-  it('should be defined', () => {
-    expect(service).toBeDefined()
+  describe('update', () => {
+    it('should create notification list, first time campaign state is updated to active', async () => {
+      const updateData: UpdateCampaignDto = {
+        state: CampaignState.active,
+      }
+
+      // Return updated data
+      const updatedCampaign = { ...mockCampaign, ...updateData }
+      prismaMock.campaign.update.mockResolvedValue(updatedCampaign)
+
+      jest.spyOn(marketing, 'createNewContactList').mockImplementation(async () => 'list-id')
+      jest.spyOn(marketing, 'updateContactList').mockImplementation(async () => '')
+      jest.spyOn(service, 'createCampaignNotificationList')
+
+      expect(await service.update(mockUpdateCampaign.id, updateData, mockCampaign)).toEqual(
+        updatedCampaign,
+      )
+
+      expect(prismaMock.campaign.update).toHaveBeenCalledWith({
+        where: { id: mockCampaign.id },
+        data: updateData,
+      })
+      expect(service.createCampaignNotificationList).toHaveBeenCalledWith(updatedCampaign)
+      expect(marketing.createNewContactList).toHaveBeenCalledWith({
+        name: updatedCampaign.title,
+      })
+      expect(prismaMock.notificationList.create).toHaveBeenCalledWith({
+        data: {
+          id: 'list-id',
+          campaignId: updatedCampaign.id,
+          name: updatedCampaign.title,
+        },
+      })
+      // Since there was no notification list for this campaign previously
+      // Should not be called
+      expect(marketing.updateContactList).not.toHaveBeenCalled()
+    })
+
+    it('should update existing notification list name, if active campaign name is updated', async () => {
+      const updateData: UpdateCampaignDto = {
+        state: CampaignState.active,
+        title: 'New Campaign Title',
+      }
+
+      // Return updated data
+      const campaignWithList = {
+        ...mockCampaign,
+        notificationLists: [
+          {
+            id: 'campaign-list-id',
+            name: 'camapign-name',
+            campaignId: mockCampaign.id,
+          },
+        ],
+      }
+      const updatedCampaign = { ...mockCampaign, ...updateData }
+
+      prismaMock.campaign.update.mockResolvedValue(updatedCampaign)
+
+      jest.spyOn(marketing, 'createNewContactList').mockImplementation(async () => '')
+      jest.spyOn(marketing, 'updateContactList').mockImplementation(async () => '')
+      jest.spyOn(service, 'createCampaignNotificationList')
+      jest.spyOn(service, 'updateCampaignNotificationList')
+
+      expect(await service.update(campaignWithList.id, updateData, campaignWithList)).toEqual(
+        updatedCampaign,
+      )
+
+      expect(prismaMock.campaign.update).toHaveBeenCalledWith({
+        where: { id: campaignWithList.id },
+        data: updateData,
+      })
+      // Since notification list exists  for this campaign
+      expect(service.createCampaignNotificationList).not.toHaveBeenCalled()
+      // Should be called
+      expect(service.updateCampaignNotificationList).toHaveBeenCalledWith(
+        updatedCampaign,
+        campaignWithList.notificationLists[0],
+      )
+      expect(marketing.updateContactList).toHaveBeenCalledWith({
+        data: { name: updatedCampaign.title },
+        id: campaignWithList.notificationLists[0].id,
+      })
+      expect(prismaMock.notificationList.update).toHaveBeenCalledWith({
+        where: { id: campaignWithList.notificationLists[0].id },
+        data: {
+          name: updatedCampaign.title,
+        },
+      })
+    })
   })
 })

--- a/apps/api/src/campaign/dto/campaign-subscribe.dto.ts
+++ b/apps/api/src/campaign/dto/campaign-subscribe.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Expose } from 'class-transformer'
+import { IsBoolean, IsEmail } from 'class-validator'
+
+export class CampaignSubscribeDto {
+  @ApiProperty()
+  @Expose()
+  @IsEmail()
+  email: string
+
+  @ApiProperty()
+  @Expose()
+  @IsBoolean()
+  consent: boolean
+}

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -21,6 +21,7 @@ export default () => ({
     sender: process.env.SENDGRID_SENDER_EMAIL,
     internalNotificationsEmail: process.env.SENDGRID_INTERNAL_EMAIL,
     contactsUrl: process.env.SENDGRID_CONTACTS_URL,
+    marketingListId: process.env.MARKETING_LIST_ID,
   },
   stripe: {
     secretKey: process.env.STRIPE_SECRET_KEY,
@@ -47,5 +48,5 @@ export default () => ({
   },
   tasks: {
     import_transactions: { interval: process.env.IMPORT_TRX_TASK_INTERVAL_MINUTES },
-  }
+  },
 })

--- a/apps/api/src/domain/generated/campaign/entities/campaign.entity.ts
+++ b/apps/api/src/domain/generated/campaign/entities/campaign.entity.ts
@@ -13,6 +13,7 @@ import { Vault } from '../../vault/entities/vault.entity'
 import { Withdrawal } from '../../withdrawal/entities/withdrawal.entity'
 import { SlugArchive } from '../../slugArchive/entities/slugArchive.entity'
 import { CampaignNews } from '../../campaignNews/entities/campaignNews.entity'
+import { NotificationList } from '../../notificationList/entities/notificationList.entity'
 
 export class Campaign {
   id: string
@@ -51,4 +52,5 @@ export class Campaign {
   withdrawals?: Withdrawal[]
   slugArchive?: SlugArchive[]
   campaignNews?: CampaignNews[]
+  notificationLists?: NotificationList[]
 }

--- a/apps/api/src/domain/generated/notificationList/dto/connect-notificationList.dto.ts
+++ b/apps/api/src/domain/generated/notificationList/dto/connect-notificationList.dto.ts
@@ -1,0 +1,3 @@
+export class ConnectNotificationListDto {
+  id: string
+}

--- a/apps/api/src/domain/generated/notificationList/dto/create-notificationList.dto.ts
+++ b/apps/api/src/domain/generated/notificationList/dto/create-notificationList.dto.ts
@@ -1,0 +1,3 @@
+export class CreateNotificationListDto {
+  name?: string
+}

--- a/apps/api/src/domain/generated/notificationList/dto/index.ts
+++ b/apps/api/src/domain/generated/notificationList/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './connect-notificationList.dto'
+export * from './create-notificationList.dto'
+export * from './update-notificationList.dto'

--- a/apps/api/src/domain/generated/notificationList/dto/update-notificationList.dto.ts
+++ b/apps/api/src/domain/generated/notificationList/dto/update-notificationList.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateNotificationListDto {
+  name?: string
+}

--- a/apps/api/src/domain/generated/notificationList/entities/index.ts
+++ b/apps/api/src/domain/generated/notificationList/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './notificationList.entity'

--- a/apps/api/src/domain/generated/notificationList/entities/notificationList.entity.ts
+++ b/apps/api/src/domain/generated/notificationList/entities/notificationList.entity.ts
@@ -1,0 +1,8 @@
+import { Campaign } from '../../campaign/entities/campaign.entity'
+
+export class NotificationList {
+  id: string
+  campaignId: string
+  name: string | null
+  campaign?: Campaign
+}

--- a/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/connect-unregisteredNotificationConsent.dto.ts
+++ b/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/connect-unregisteredNotificationConsent.dto.ts
@@ -1,0 +1,4 @@
+export class ConnectUnregisteredNotificationConsentDto {
+  id?: string
+  email?: string
+}

--- a/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/create-unregisteredNotificationConsent.dto.ts
+++ b/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/create-unregisteredNotificationConsent.dto.ts
@@ -1,0 +1,3 @@
+export class CreateUnregisteredNotificationConsentDto {
+  email: string
+}

--- a/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/index.ts
+++ b/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './connect-unregisteredNotificationConsent.dto'
+export * from './create-unregisteredNotificationConsent.dto'
+export * from './update-unregisteredNotificationConsent.dto'

--- a/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/update-unregisteredNotificationConsent.dto.ts
+++ b/apps/api/src/domain/generated/unregisteredNotificationConsent/dto/update-unregisteredNotificationConsent.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateUnregisteredNotificationConsentDto {
+  email?: string
+}

--- a/apps/api/src/domain/generated/unregisteredNotificationConsent/entities/index.ts
+++ b/apps/api/src/domain/generated/unregisteredNotificationConsent/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './unregisteredNotificationConsent.entity'

--- a/apps/api/src/domain/generated/unregisteredNotificationConsent/entities/unregisteredNotificationConsent.entity.ts
+++ b/apps/api/src/domain/generated/unregisteredNotificationConsent/entities/unregisteredNotificationConsent.entity.ts
@@ -1,0 +1,5 @@
+export class UnregisteredNotificationConsent {
+  id: string
+  email: string
+  consent: boolean
+}

--- a/apps/api/src/donations/donations.controller.spec.ts
+++ b/apps/api/src/donations/donations.controller.spec.ts
@@ -21,6 +21,7 @@ import { DonationsService } from './donations.service'
 import { CreateSessionDto } from './dto/create-session.dto'
 import { UpdatePaymentDto } from './dto/update-payment.dto'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('DonationsController', () => {
   let controller: DonationsController
@@ -66,7 +67,7 @@ describe('DonationsController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [NotificationModule],
+      imports: [NotificationModule, MarketingNotificationsModule],
       controllers: [DonationsController],
       providers: [
         {

--- a/apps/api/src/donations/donations.module.ts
+++ b/apps/api/src/donations/donations.module.ts
@@ -17,6 +17,7 @@ import { StripePaymentService } from './events/stripe-payment.service'
 import { HttpModule } from '@nestjs/axios'
 import { ExportModule } from './../export/export.module'
 import { NotificationModule } from '../sockets/notifications/notification.module'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { NotificationModule } from '../sockets/notifications/notification.module
     HttpModule,
     ExportModule,
     NotificationModule,
+    MarketingNotificationsModule,
   ],
   controllers: [DonationsController],
   providers: [

--- a/apps/api/src/donations/donations.service.spec.ts
+++ b/apps/api/src/donations/donations.service.spec.ts
@@ -9,13 +9,14 @@ import { NotificationModule } from '../sockets/notifications/notification.module
 import { VaultModule } from '../vault/vault.module'
 import { VaultService } from '../vault/vault.service'
 import { DonationsService } from './donations.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('DonationsService', () => {
   let service: DonationsService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [VaultModule, NotificationModule],
+      imports: [VaultModule, NotificationModule, MarketingNotificationsModule],
       providers: [
         ConfigService,
         CampaignService,

--- a/apps/api/src/donations/events/stripe-payment.service.spec.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.spec.ts
@@ -35,6 +35,7 @@ import { RecurringDonationService } from '../../recurring-donation/recurring-don
 import { HttpService } from '@nestjs/axios'
 import { mockDeep } from 'jest-mock-extended'
 import { NotificationModule } from '../../sockets/notifications/notification.module'
+import { MarketingNotificationsModule } from '../../notifications/notifications.module'
 
 const defaultStripeWebhookEndpoint = '/stripe/webhook'
 const stripeSecret = 'wh_123'
@@ -63,6 +64,7 @@ describe('StripePaymentService', () => {
           useFactory: () => moduleConfig,
         }),
         NotificationModule,
+        MarketingNotificationsModule,
       ],
       providers: [
         ConfigService,

--- a/apps/api/src/notifications/notifications.interface.ts
+++ b/apps/api/src/notifications/notifications.interface.ts
@@ -1,0 +1,15 @@
+type NotificationsInterfaceParams = {
+  CreateListParams: any
+  UpdateListParams: any
+  DeleteListParams: any
+  AddToListParams: any
+  RemoveFromListParams: any
+}
+
+export abstract class NotificationsInterface<T extends NotificationsInterfaceParams> {
+  abstract createNewContactList(data: T['CreateListParams']): Promise<string>
+  abstract updateContactList(data: T['UpdateListParams']): Promise<any>
+  abstract deleteContactList(data: T['DeleteListParams']): Promise<any>
+  abstract addContactsToList(data: T['AddToListParams']): Promise<any>
+  abstract removeContactsFromList(data: T['RemoveFromListParams']): Promise<any>
+}

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common'
+import { SendGridNotificationsService } from './notifications.sendgrid.service'
+import { NotificationsInterface } from './notifications.interface'
+import { ConfigModule } from '@nestjs/config'
+
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      // Use the interface as token
+      provide: NotificationsInterface,
+      // But actually provide the service that implements the interface
+      useClass: SendGridNotificationsService,
+    },
+  ],
+  exports: [
+    {
+      provide: NotificationsInterface,
+      useClass: SendGridNotificationsService,
+    },
+  ],
+})
+export class MarketingNotificationsModule {}

--- a/apps/api/src/notifications/notifications.sendgrid.service.ts
+++ b/apps/api/src/notifications/notifications.sendgrid.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import sgClient from '@sendgrid/client'
+import { NotificationsInterface } from './notifications.interface'
+import { SendGridParams } from './notifications.sendgrid.types'
+import { ClientRequest } from '@sendgrid/client/src/request'
+
+@Injectable()
+export class SendGridNotificationsService implements NotificationsInterface<SendGridParams> {
+  private emailSender: string
+
+  constructor(private config: ConfigService) {
+    const apiKey = config.get<string>('sendgrid.apiKey')
+    this.emailSender = this.config.get<string>('sendgrid.sender') ?? 'info@podkrepi.bg'
+    if (apiKey) {
+      sgClient.setApiKey(apiKey)
+    } else {
+      Logger.warn('no apiKey for sendgrid, will not send notifications')
+    }
+  }
+
+  async createNewContactList(data: SendGridParams['CreateListParams']) {
+    const request = {
+      url: `/v3/marketing/lists`,
+      method: 'POST',
+      body: data,
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    const listId = response?.body['id'] as string
+
+    return listId
+  }
+
+  async updateContactList(data: SendGridParams['UpdateListParams']) {
+    const request = {
+      url: `/v3/marketing/lists/${data.id}`,
+      method: 'PATCH',
+      body: data.data,
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    return response
+  }
+
+  async deleteContactList(data: SendGridParams['DeleteListParams']) {
+    const request = {
+      url: `/v3/marketing/lists/${data.id}`,
+      method: 'DELETE',
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    return response
+  }
+
+  async addContactsToList(data: SendGridParams['AddToListParams']) {
+    const request = {
+      url: `/v3/marketing/contacts`,
+      method: 'PUT',
+      body: data,
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    return response
+  }
+
+  async removeContactsFromList(data: SendGridParams['RemoveFromListParams']) {
+    const contact_ids = data.contact_ids.join(',')
+
+    const request = {
+      url: `/v3/marketing/lists/${data.list_id}/contacts`,
+      method: 'DELETE',
+      qs: { contact_ids },
+    } as ClientRequest
+
+    const [response] = await sgClient.request(request)
+
+    return response
+  }
+}

--- a/apps/api/src/notifications/notifications.sendgrid.types.ts
+++ b/apps/api/src/notifications/notifications.sendgrid.types.ts
@@ -1,0 +1,38 @@
+export type SendGridParams = {
+  CreateListParams: CreateListParams
+  UpdateListParams: UpdateListParams
+  DeleteListParams: DeleteListParams
+  AddToListParams: AddToListParams
+  RemoveFromListParams: RemoveFromListParams
+  ContactData: ContactData
+}
+
+type CreateListParams = {
+  name: string
+}
+
+type UpdateListParams = {
+  id: string
+  data: { [key: string]: any }
+}
+
+type DeleteListParams = {
+  id: string
+}
+
+type ContactData = {
+  email: string
+  first_name?: string
+  last_name?: string
+  custom_fields?: { [key: string]: string | number }
+}
+
+type AddToListParams = {
+  contacts: ContactData[]
+  list_ids?: string[]
+}
+
+type RemoveFromListParams = {
+  list_id: string
+  contact_ids: string[]
+}

--- a/apps/api/src/paypal/paypal.controller.spec.ts
+++ b/apps/api/src/paypal/paypal.controller.spec.ts
@@ -7,12 +7,21 @@ import { ConfigModule } from '@nestjs/config'
 import { HttpModule } from '@nestjs/axios'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
+
 describe('PaypalController', () => {
   let controller: PaypalController
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [PaypalModule, CampaignModule, ConfigModule, HttpModule, NotificationModule],
+      imports: [
+        PaypalModule,
+        CampaignModule,
+        MarketingNotificationsModule,
+        ConfigModule,
+        HttpModule,
+        NotificationModule,
+      ],
       controllers: [PaypalController],
       providers: [PaypalService],
     }).compile()

--- a/apps/api/src/paypal/paypal.service.spec.ts
+++ b/apps/api/src/paypal/paypal.service.spec.ts
@@ -5,13 +5,21 @@ import { CampaignModule } from '../campaign/campaign.module'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { PaypalModule } from './paypal.module'
 import { PaypalService } from './paypal.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('PaypalService', () => {
   let service: PaypalService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [PaypalModule, CampaignModule, ConfigModule, HttpModule, NotificationModule],
+      imports: [
+        PaypalModule,
+        CampaignModule,
+        ConfigModule,
+        HttpModule,
+        NotificationModule,
+        MarketingNotificationsModule,
+      ],
       providers: [PaypalService],
     }).compile()
 

--- a/apps/api/src/person/person.controller.spec.ts
+++ b/apps/api/src/person/person.controller.spec.ts
@@ -3,12 +3,14 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { MockPrismaService } from '../prisma/prisma-client.mock'
 import { PersonController } from './person.controller'
 import { PersonService } from './person.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('PersonController', () => {
   let controller: PersonController
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [MarketingNotificationsModule],
       controllers: [PersonController],
       providers: [PersonService, MockPrismaService, ConfigService],
     })

--- a/apps/api/src/person/person.service.spec.ts
+++ b/apps/api/src/person/person.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 import { ConfigService } from '@nestjs/config'
 import { MockPrismaService, prismaMock } from '../prisma/prisma-client.mock'
 import { PersonService } from './person.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 const mockPerson = {
   firstName: 'test',
@@ -19,6 +20,7 @@ describe('PersonService with enable client list ', () => {
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [MarketingNotificationsModule],
       providers: [PersonService, MockPrismaService, ConfigService],
     })
       .overrideProvider(ConfigService)

--- a/apps/api/src/person/person.service.ts
+++ b/apps/api/src/person/person.service.ts
@@ -38,6 +38,10 @@ export class PersonService {
     return await this.prisma.person.findFirst({ where: { id } })
   }
 
+  async findByEmail(email: string) {
+    return await this.prisma.person.findFirst({ where: { email } })
+  }
+
   async findOneByKeycloakId(keycloakId: string) {
     return await this.prisma.person.findFirst({ where: { keycloakId } })
   }
@@ -70,5 +74,21 @@ export class PersonService {
     } catch (error) {
       Logger.warn(`Adding person to contacts list failed with code: ${error.code}`)
     }
+  }
+
+  // Create/Update a marketing notifications consent for emails that are not registered
+  async upsertUnregisteredNotificationConsent(email: string, consent: boolean) {
+    await this.prisma.unregisteredNotificationConsent.upsert({
+      // Create new record
+      create: {
+        email,
+        consent,
+      },
+      // Update consent
+      update: { consent },
+      where: {
+        email,
+      },
+    })
   }
 }

--- a/apps/api/src/tasks/bank-import/import-transactions.task.spec.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.spec.ts
@@ -19,6 +19,8 @@ import { toMoney } from '../../common/money'
 import { DateTime } from 'luxon'
 import { EmailService } from '../../email/email.service'
 import { TemplateService } from '../../email/template.service'
+import { NotificationsInterface } from '../../notifications/notifications.interface'
+import { SendGridNotificationsService } from '../../notifications/notifications.sendgrid.service'
 
 const IBAN = 'BG77UNCR92900016740920'
 
@@ -187,6 +189,10 @@ describe('ImportTransactionsTask', () => {
         SchedulerRegistry,
         EmailService,
         TemplateService,
+        {
+          provide: NotificationsInterface,
+          useClass: SendGridNotificationsService,
+        },
       ],
     })
       .overrideProvider(PersonService)

--- a/apps/api/src/tasks/tasks-initializer.service.spec.ts
+++ b/apps/api/src/tasks/tasks-initializer.service.spec.ts
@@ -16,6 +16,7 @@ import { ExportService } from '../export/export.service'
 import { TasksInitializer } from './tasks-initializer.service'
 import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('ImportTransactionsTask', () => {
   let taskService: TasksInitializer
@@ -38,7 +39,7 @@ describe('ImportTransactionsTask', () => {
 
   beforeEach(async () => {
     testModule = await Test.createTestingModule({
-      imports: [HttpModule, NotificationModule],
+      imports: [HttpModule, NotificationModule, MarketingNotificationsModule],
       providers: [
         IrisTasks,
         MockPrismaService,

--- a/apps/api/src/vault/vault.controller.spec.ts
+++ b/apps/api/src/vault/vault.controller.spec.ts
@@ -1,4 +1,4 @@
-import { ConfigService } from '@nestjs/config'
+import { ConfigModule, ConfigService } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
 import { UnauthorizedException } from '@nestjs/common'
 import { CampaignService } from '../campaign/campaign.service'
@@ -9,6 +9,7 @@ import { KeycloakTokenParsed } from '../auth/keycloak'
 import { Currency } from '@prisma/client'
 import { MockPrismaService, prismaMock } from '../prisma/prisma-client.mock'
 import { CreateVaultDto } from './dto/create-vault.dto'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('VaultController', () => {
   let controller: VaultController
@@ -23,6 +24,7 @@ describe('VaultController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [MarketingNotificationsModule],
       controllers: [VaultController],
       providers: [
         VaultService,

--- a/apps/api/src/vault/vault.module.ts
+++ b/apps/api/src/vault/vault.module.ts
@@ -7,8 +7,9 @@ import { PrismaService } from '../prisma/prisma.service'
 import { VaultController } from './vault.controller'
 import { VaultService } from './vault.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 @Module({
-  imports: [forwardRef(() => CampaignModule), NotificationModule],
+  imports: [forwardRef(() => CampaignModule), NotificationModule, MarketingNotificationsModule],
 
   controllers: [VaultController],
   providers: [VaultService, CampaignService, PrismaService, PersonService, ConfigService],

--- a/apps/api/src/vault/vault.service.spec.ts
+++ b/apps/api/src/vault/vault.service.spec.ts
@@ -6,13 +6,14 @@ import { PersonService } from '../person/person.service'
 import { MockPrismaService } from '../prisma/prisma-client.mock'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { VaultService } from './vault.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('VaultService', () => {
   let service: VaultService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [CampaignModule, NotificationModule],
+      imports: [CampaignModule, NotificationModule, MarketingNotificationsModule],
       providers: [VaultService, MockPrismaService, CampaignService, PersonService, ConfigService],
     }).compile()
 

--- a/apps/api/src/withdrawal/withdrawal.controller.spec.ts
+++ b/apps/api/src/withdrawal/withdrawal.controller.spec.ts
@@ -7,6 +7,7 @@ import { CreateWithdrawalDto } from './dto/create-withdrawal.dto'
 import { UpdateWithdrawalDto } from './dto/update-withdrawal.dto'
 import { WithdrawalController } from './withdrawal.controller'
 import { WithdrawalService } from './withdrawal.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 const mockData = [
   {
@@ -62,6 +63,7 @@ describe('WithdrawalController', () => {
     prismaMock.withdrawal.findMany.mockResolvedValue(mockData)
 
     const module: TestingModule = await Test.createTestingModule({
+      imports: [MarketingNotificationsModule],
       controllers: [WithdrawalController],
       providers: [WithdrawalService, MockPrismaService],
     }).compile()

--- a/apps/api/src/withdrawal/withdrawal.service.spec.ts
+++ b/apps/api/src/withdrawal/withdrawal.service.spec.ts
@@ -1,13 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { MockPrismaService } from '../prisma/prisma-client.mock'
 import { WithdrawalService } from './withdrawal.service'
+import { MarketingNotificationsModule } from '../notifications/notifications.module'
 
 describe('WithdrawalService', () => {
   let service: WithdrawalService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [WithdrawalService, MockPrismaService],
+      providers: [WithdrawalService, MockPrismaService, MarketingNotificationsModule],
     }).compile()
 
     service = module.get<WithdrawalService>(WithdrawalService)

--- a/migrations/20230724081135_add_notification_list_table/migration.sql
+++ b/migrations/20230724081135_add_notification_list_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "notification_list" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "campaign_id" UUID NOT NULL,
+    "name" TEXT,
+
+    CONSTRAINT "notification_list_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "notification_list" ADD CONSTRAINT "notification_list_campaign_id_fkey" FOREIGN KEY ("campaign_id") REFERENCES "campaigns"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/migrations/20230724081305_add_unregistered_consent_table/migration.sql
+++ b/migrations/20230724081305_add_unregistered_consent_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "unregistered_notification_consent" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "email" CITEXT NOT NULL,
+    "consent" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "unregistered_notification_consent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "unregistered_notification_consent_email_key" ON "unregistered_notification_consent"("email");

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -173,6 +173,7 @@ Table campaigns {
   withdrawals withdrawals [not null]
   slugArchive slug_archive [not null]
   campaignNews campaign_news [not null]
+  notificationLists notification_list [not null]
 }
 
 Table campaign_news {
@@ -191,6 +192,19 @@ Table campaign_news {
   campaign campaigns [not null]
   publisher people [not null]
   newsFiles campaign_news_files [not null]
+}
+
+Table notification_list {
+  id String [pk]
+  campaignId String [not null]
+  name String
+  campaign campaigns [not null]
+}
+
+Table unregistered_notification_consent {
+  id String [pk]
+  email String [unique, not null]
+  consent Boolean [not null, default: false]
 }
 
 Table slug_archive {
@@ -762,6 +776,8 @@ Ref: campaigns.companyId > companies.id
 Ref: campaign_news.campaignId > campaigns.id
 
 Ref: campaign_news.publisherId > people.id
+
+Ref: notification_list.campaignId > campaigns.id
 
 Ref: slug_archive.campaignId > campaigns.id
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -40,6 +40,7 @@ model Person {
   company            String?             @db.VarChar(50)
   createdAt          DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt          DateTime?           @updatedAt @map("updated_at") @db.Timestamptz(6)
+  // Receive marketing notifications
   newsletter         Boolean?            @default(false)
   address            String?             @db.VarChar(100)
   birthday           DateTime?           @db.Timestamptz(6)
@@ -178,42 +179,43 @@ model CampaignType {
 }
 
 model Campaign {
-  id                      String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  state                   CampaignState  @default(draft)
-  slug                    String         @unique @db.VarChar(250)
-  title                   String         @db.VarChar(200)
-  essence                 String         @db.VarChar(500)
-  coordinatorId           String         @map("coordinator_id") @db.Uuid
-  beneficiaryId           String         @map("beneficiary_id") @db.Uuid
-  campaignTypeId          String         @map("campaign_type_id") @db.Uuid
+  id                      String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  state                   CampaignState       @default(draft)
+  slug                    String              @unique @db.VarChar(250)
+  title                   String              @db.VarChar(200)
+  essence                 String              @db.VarChar(500)
+  coordinatorId           String              @map("coordinator_id") @db.Uuid
+  beneficiaryId           String              @map("beneficiary_id") @db.Uuid
+  campaignTypeId          String              @map("campaign_type_id") @db.Uuid
   description             String?
-  targetAmount            Int?           @default(0) @map("target_amount")
-  startDate               DateTime?      @map("start_date") @db.Timestamptz(6)
-  endDate                 DateTime?      @map("end_date") @db.Timestamptz(6)
-  createdAt               DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt               DateTime?      @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt               DateTime?      @map("deleted_at") @db.Timestamptz(6)
-  approvedById            String?        @map("approved_by_id") @db.Uuid
-  currency                Currency       @default(BGN)
-  allowDonationOnComplete Boolean        @default(false) @map("allow_donation_on_complete")
-  paymentReference        String         @unique @map("payment_reference") @db.VarChar(15)
-  organizerId             String?        @map("organizer_id") @db.Uuid
-  companyId               String?        @map("company_id") @db.Uuid
-  approvedBy              Person?        @relation(fields: [approvedById], references: [id])
-  beneficiary             Beneficiary    @relation(fields: [beneficiaryId], references: [id])
-  campaignType            CampaignType   @relation(fields: [campaignTypeId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  coordinator             Coordinator    @relation(fields: [coordinatorId], references: [id])
-  organizer               Organizer?     @relation(fields: [organizerId], references: [id])
-  company                 Company?       @relation(fields: [companyId], references: [id])
+  targetAmount            Int?                @default(0) @map("target_amount")
+  startDate               DateTime?           @map("start_date") @db.Timestamptz(6)
+  endDate                 DateTime?           @map("end_date") @db.Timestamptz(6)
+  createdAt               DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt               DateTime?           @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt               DateTime?           @map("deleted_at") @db.Timestamptz(6)
+  approvedById            String?             @map("approved_by_id") @db.Uuid
+  currency                Currency            @default(BGN)
+  allowDonationOnComplete Boolean             @default(false) @map("allow_donation_on_complete")
+  paymentReference        String              @unique @map("payment_reference") @db.VarChar(15)
+  organizerId             String?             @map("organizer_id") @db.Uuid
+  companyId               String?             @map("company_id") @db.Uuid
+  approvedBy              Person?             @relation(fields: [approvedById], references: [id])
+  beneficiary             Beneficiary         @relation(fields: [beneficiaryId], references: [id])
+  campaignType            CampaignType        @relation(fields: [campaignTypeId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  coordinator             Coordinator         @relation(fields: [coordinatorId], references: [id])
+  organizer               Organizer?          @relation(fields: [organizerId], references: [id])
+  company                 Company?            @relation(fields: [companyId], references: [id])
   campaignFiles           CampaignFile[]
   donationWish            DonationWish[]
   irregularities          Irregularity[]
-  outgoingTransfers       Transfer[]     @relation("source_campaign")
-  incomingTransfers       Transfer[]     @relation("target_campaign")
+  outgoingTransfers       Transfer[]          @relation("source_campaign")
+  incomingTransfers       Transfer[]          @relation("target_campaign")
   vaults                  Vault[]
   withdrawals             Withdrawal[]
   slugArchive             SlugArchive[]
   campaignNews            CampaignNews[]
+  notificationLists       NotificationList[]
 
   @@map("campaigns")
 }
@@ -236,6 +238,24 @@ model CampaignNews {
   newsFiles   CampaignNewsFile[]
 
   @@map("campaign_news")
+}
+
+model NotificationList {
+  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  campaignId String   @map("campaign_id") @db.Uuid
+  name       String?
+  campaign   Campaign @relation(fields: [campaignId], references: [id])
+
+  @@map("notification_list")
+}
+
+// Stores marketing notifications consents for non-registered emails
+model UnregisteredNotificationConsent {
+  id      String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email   String  @unique @db.Citext
+  consent Boolean @default(false)
+
+  @@map("unregistered_notification_consent")
 }
 
 /// Keeps track of previous slugs that are not used currently in any active campaign


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Depend on this FE PR -> podkrepi-bg/frontend#1517


Added functionality to subscribe to marketing notifications in SendGrid. Two types of notifications would exist.
1. General marketing notifications (Platform realated news, New campaign has been published, Blog Posts etc),
2. Campaign Specific notifications - % of amount raised, campaign news, campaign completed etc.a

 - So basically this PR takes care of generating mailing lists in SendGrid and managing subscriptions to them(adding emails). The actual sending would be implemented in the next PR. Visual example of how those lists look like in SendGrid:

![image](https://github.com/podkrepi-bg/api/assets/78339364/4dcd9162-1f02-42d1-bc46-fd4d8207c34a)

- The `All Marketing Emails` List is where all emails that gave their consent(registered and not) are placed
- Additionaly if an email subscribes to a particular campaign it will also be added to the list for that camapign
 
NOTE: This is the First part of the implementation. The next one will add:

1. Ability to un-subscribe - logged in or not
2. Ability to manage notification consent and saparate campaign notification subscriptions of logged users
4. The actual sending of emails to the different mailing groups (General and Campaign based)




## How it works
1. In the register route a new flag is accepted `{newsletter:boolean}` which marks if the user has accepted to receive marketing notifications. A checkBox has been added on the FE as well.
  - If the flag is true the user consent is saved in the DB and the email itself is added ot the `All Marketing Emails` List to receive notifications
 2. In the route for updating campaigns -  logic has been added so that the mailing lists are created automatically in Sendgrid for the updated campaign. The logic is as follows:
  - If no list exists for the campaign and it's state is updated to active - an API call is made to SendGrid to create the lists with the campaign name and also another record in a new table in the DB is created that tracks the mailing list SendGrid Id for that camapaign
  - If the campaign is active and already has an email list and If the campaign title is updated and api call is send to SendGRid to update the list with the new name
  3. A new route is created in the campaign controller - `/campaign/:id/subscribe`. It is `PUBLIC`, so that all interested visitors can subscribe to it. You can check the FE PR to see how it should work. The consent for non-registered emails are stored in a new DB table.  NOTE: currently it directly adds the provided email to the `All Marketing Emails` List + the mailing list for that campaign. In the next PR this shall get modified, so that we will send an email that would contain the actual verification link. This way we would filter out some spam and fake emails.
 4. Wrote tests for the new functionality


NOTE: The Service for managing notifications is implemented trough an `INTERFACE`, the idea is that it should be easier to switch to another marketing provider if we decide that SendGrid is not OK for us.


### New endpoints

`/campaign/:id/subscribe`

## Environment

### New environment variables:

MARKETING_LIST_ID

<!-- Mark with [x] when variable is added to `.env.example`  -->

- [ ] `MARKETING_LIST_ID`: the Sendgrid list where all emails that gave consent would be stored - a.k.a All Marketing Emails or whatever it's called
