### PR TITLE
fix: payment reference code to not contain confusable symbols

### DIFF
--- a/apps/api/src/campaign/helpers/payment-reference.ts
+++ b/apps/api/src/campaign/helpers/payment-reference.ts
@@ -1,11 +1,11 @@
-import { customAlphabet as paymentReferenceGenerator } from 'nanoid'
+import { customAlphabet as paymentReferenceGenerator } from 'nanoid';
 
-const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-const nanoid = paymentReferenceGenerator(alphabet, 12)
+const alphabet = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'; // Exclude 0, 1, O, I, L
+const nanoid = paymentReferenceGenerator(alphabet, 12);
 
 export function getPaymentReference(): string {
-  let id: string = nanoid() //=> "NY5PKVO4DNBZ"
+  let id: string = nanoid(); //=> "NY5PKVO4DNBZ"
   //add dashes for readability "NY5P-KVO4-DNBZ"
-  id = id.slice(0, 4) + '-' + id.slice(4, 8) + '-' + id.slice(8, 12)
-  return id
+  id = id.slice(0, 4) + '-' + id.slice(4, 8) + '-' + id.slice(8, 12);
+  return id;
 }


### PR DESCRIPTION
Closes #522 

## Motivation and context

Newly generated payment reference will exclude the following: 0, 1, O, I, L

## Testing

### Steps to test

- Reset database
- Start api and frontend 
- Go to any campaigns donation page and open the bank donation option 
- Check the payment reference

