### PR TITLE
Create a new internal campaing for members and their fees.

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -791,4 +791,12 @@ export class CampaignService {
 
     return articles
   }
+
+  async isMembershipCampaign(campaignTypeId: string): Promise<boolean> {
+    const campaignType = await this.prisma.campaignType.findUnique({
+      where: { id: campaignTypeId },
+    })
+
+    return campaignType?.name.toLowerCase() === 'membership'
+  }
 }

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -239,13 +239,18 @@ export class DonationsService {
     campaign: Campaign,
   ): Promise<Stripe.Checkout.SessionCreateParams.LineItem[]> {
     if (sessionDto.mode == 'subscription') {
+      // the membership campaign is internal only
+      // we need to make the subscriptions once a year
+      const isMembership = await this.campaignService.isMembershipCampaign(campaign.campaignTypeId)
+      const interval = isMembership ? 'year' : 'month'
+
       //use an inline price for subscriptions
       const stripeItem = {
         price_data: {
           currency: campaign.currency,
           unit_amount: sessionDto.amount,
           recurring: {
-            interval: 'month' as Stripe.Price.Recurring.Interval,
+            interval: interval as Stripe.Price.Recurring.Interval,
             interval_count: 1,
           },
           product_data: {

--- a/migrations/20230802161354_insert_membership_campaign_type/migration.sql
+++ b/migrations/20230802161354_insert_membership_campaign_type/migration.sql
@@ -1,0 +1,5 @@
+-- Add a new campaign type for membership campaigns
+
+INSERT INTO api.campaign_types (name, slug, description, parent_id, category)
+VALUES ('Membership', 'membership', 'Membership Campaigns', null, 'others');
+

--- a/migrations/20230802163505_insert_membership_campaign/migration.sql
+++ b/migrations/20230802163505_insert_membership_campaign/migration.sql
@@ -1,19 +1,20 @@
 --insert an internal campaign for members only and their membership fee
-
-select * from api.beneficiaries
-
+--insert an internal campaign for members only and their membership fee
 DO $$
 DECLARE
   v_coordinator_id UUID;
   v_beneficiary_id UUID;
   v_campaign_type_id UUID;
+
 BEGIN
 
-
-
-select id INTO v_coordinator_id from coordinators where name limit 1;
-select id INTO v_beneficiary_id from beneficiaries limit 1;
+select id INTO v_coordinator_id from coordinators limit 1;
+select id INTO v_beneficiary_id from beneficiaries where coordinator_id = v_coordinator_id limit 1;
 select id INTO v_campaign_type_id from campaign_types where name = 'Membership';
+
+IF v_beneficiary_id IS NULL THEN
+    RETURN;
+END IF;
 
 insert into campaigns (
 	state,
@@ -51,3 +52,4 @@ values ('approved',
 	   );
 END;
 $$ LANGUAGE plpgsql;
+

--- a/migrations/20230802163505_insert_membership_campaign/migration.sql
+++ b/migrations/20230802163505_insert_membership_campaign/migration.sql
@@ -1,0 +1,53 @@
+--insert an internal campaign for members only and their membership fee
+
+select * from api.beneficiaries
+
+DO $$
+DECLARE
+  v_coordinator_id UUID;
+  v_beneficiary_id UUID;
+  v_campaign_type_id UUID;
+BEGIN
+
+
+
+select id INTO v_coordinator_id from coordinators where name limit 1;
+select id INTO v_beneficiary_id from beneficiaries limit 1;
+select id INTO v_campaign_type_id from campaign_types where name = 'Membership';
+
+insert into campaigns (
+	state,
+	slug,
+	title,
+	coordinator_id,
+	beneficiary_id,
+	campaign_type_id,
+	essence,
+	description,
+	target_amount,
+	start_date,
+	end_date,
+	created_at,
+	updated_at,
+	currency,
+	allow_donation_on_complete,
+	payment_reference)
+values ('approved',
+		'podkrepi-membership',
+		'Podkrepi.bg membership',
+		v_coordinator_id,
+		v_beneficiary_id,
+		v_campaign_type_id,
+		'Internal campaign for members only',
+		'Internal campaign for members only. Here you can pay your membership fee. Subscribe it as an annual donation in this campaign.',
+		10000000,
+		NOW(),
+		'2123-08-01',
+		NOW(),
+		NOW(),
+		'BGN',
+		true,
+		'46M3-3ARQ-R326'
+	   );
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

We already support subscriptions on the platform.
Now we can use those subscriptions to pay the annual membership fees.

The campaign that is created has an approved status.
So it is not public, but can be accessed via this link:

https://podkrepi.bg/campaigns/podkrepi-membership

<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/podkrepi-bg/frontend/issues/1530 

### Steps to test
Open the link:
https://podkrepi.bg/campaigns/podkrepi-membership

Then click to donate and select the subscription checkbox.
Although it says "monthly", the donation will be annual in Stripe:

![image](https://github.com/podkrepi-bg/api/assets/99622/c3d7a59e-cef9-4217-a04b-7454f074b2f6)

Currently we select a random coordinator and a beneficiary, but this will be changed after deploying on production.