### PR TITLE
src/campaign-file: Set Cache-Control header

### DIFF
--- a/apps/api/src/campaign-file/campaign-file.controller.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.ts
@@ -12,7 +12,6 @@ import {
   Body,
   Inject,
   forwardRef,
-  Header,
 } from '@nestjs/common'
 import { FilesInterceptor } from '@nestjs/platform-express'
 import { UseInterceptors, UploadedFiles } from '@nestjs/common'
@@ -25,6 +24,7 @@ import { CampaignFileService } from './campaign-file.service'
 import { CampaignService } from '../campaign/campaign.service'
 import { KeycloakTokenParsed, isAdmin } from '../auth/keycloak'
 import { ApiTags } from '@nestjs/swagger';
+import { CampaignFileRole } from '@prisma/client'
 
 @ApiTags('campaign-file')
 @Controller('campaign-file')
@@ -79,7 +79,6 @@ export class CampaignFileController {
 
   @Get(':id')
   @Public()
-  @Header('Cache-Control', 'public, s-maxage=15552000, stale-while-revalidate=15552000, immutable')
   async findOne(
     @Param('id') id: string,
     @Response({ passthrough: true }) res,
@@ -88,6 +87,9 @@ export class CampaignFileController {
     res.set({
       'Content-Type': file.mimetype,
       'Content-Disposition': 'attachment; filename="' + file.filename + '"',
+      'Cache-Control': file.role === CampaignFileRole.campaignListPhoto 
+                        ? 'public, s-maxage=15552000, stale-while-revalidate=15552000, immutable' 
+                        : 'no-store'
     })
 
     return new StreamableFile(file.stream)

--- a/apps/api/src/campaign-file/campaign-file.controller.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.ts
@@ -12,6 +12,7 @@ import {
   Body,
   Inject,
   forwardRef,
+  Header,
 } from '@nestjs/common'
 import { FilesInterceptor } from '@nestjs/platform-express'
 import { UseInterceptors, UploadedFiles } from '@nestjs/common'
@@ -78,6 +79,7 @@ export class CampaignFileController {
 
   @Get(':id')
   @Public()
+  @Header('Cache-Control', 'public, s-maxage=15552000, stale-while-revalidate=15552000, immutable')
   async findOne(
     @Param('id') id: string,
     @Response({ passthrough: true }) res,

--- a/apps/api/src/campaign-file/campaign-file.controller.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.ts
@@ -87,7 +87,7 @@ export class CampaignFileController {
     res.set({
       'Content-Type': file.mimetype,
       'Content-Disposition': 'attachment; filename="' + file.filename + '"',
-      'Cache-Control': file.role === CampaignFileRole.campaignListPhoto 
+      'Cache-Control': file.mimetype.startsWith('image/')
                         ? 'public, s-maxage=15552000, stale-while-revalidate=15552000, immutable' 
                         : 'no-store'
     })

--- a/apps/api/src/campaign-file/campaign-file.service.ts
+++ b/apps/api/src/campaign-file/campaign-file.service.ts
@@ -52,6 +52,7 @@ export class CampaignFileService {
   async findOne(id: string): Promise<{
     filename: CampaignFile['filename']
     mimetype: CampaignFile['mimetype']
+    role: CampaignFile['role']
     stream: Readable
   }> {
     const file = await this.prisma.campaignFile.findFirst({ where: { id: id } })
@@ -63,6 +64,7 @@ export class CampaignFileService {
       filename: encodeURIComponent(file.filename),
       mimetype: file.mimetype,
       stream: await this.s3.streamFile(this.bucketName, id),
+      role: file.role
     }
   }
 


### PR DESCRIPTION
This would allow for images to be cached on the client, and thus result in faster load on client, as well as less calls to the server being made.  
Age of cache  is set to 6 months. 

Test:
1. Open Browser's devtools
2. Go to network tab
3. Refresh page
4. Campaign files should be loaded through disk cache.