### PR TITLE
fix updating donation after charge succeeded event

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -631,7 +631,11 @@ export class CampaignService {
 
         //if donation is switching to successful, increment the vault amount and send notification
         if (newDonationStatus === DonationStatus.succeeded) {
-          await this.vaultService.incrementVaultAmount(donation.targetVaultId, paymentData.netAmount, tx)
+          await this.vaultService.incrementVaultAmount(
+            donation.targetVaultId,
+            paymentData.netAmount,
+            tx,
+          )
           this.notificationService.sendNotification('successfulDonation', {
             ...updatedDonation,
             person: updatedDonation.person,

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -631,7 +631,7 @@ export class CampaignService {
 
         //if donation is switching to successful, increment the vault amount and send notification
         if (newDonationStatus === DonationStatus.succeeded) {
-          await this.vaultService.incrementVaultAmount(donation.targetVaultId, donation.amount, tx)
+          await this.vaultService.incrementVaultAmount(donation.targetVaultId, paymentData.netAmount, tx)
           this.notificationService.sendNotification('successfulDonation', {
             ...updatedDonation,
             person: updatedDonation.person,

--- a/apps/api/src/donations/events/stripe-payment.service.spec.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.spec.ts
@@ -242,20 +242,17 @@ describe('StripePaymentService', () => {
       targetVaultId: 'test-vault-id',
       amount: (mockInvoicePaidEvent.data.object as Stripe.Invoice).amount_paid,
       status: 'succeeded',
-      person: { firstName: "Full", lastName: "Name"},
+      person: { firstName: 'Full', lastName: 'Name' },
     } as Donation & { person: unknown })
 
-    prismaMock.vault.update.mockResolvedValue(
-      {campaignId: 'test-campaign'} as Vault
-    )
+    prismaMock.vault.update.mockResolvedValue({ campaignId: 'test-campaign' } as Vault)
 
     jest.spyOn(prismaMock, '$transaction').mockImplementation((callback) => callback(prismaMock))
     const mockedUpdateDonationPayment = jest
       .spyOn(campaignService, 'updateDonationPayment')
       .mockName('updateDonationPayment')
 
-    const mockedIncrementVaultAmount = jest
-      .spyOn(vaultService, 'incrementVaultAmount')
+    const mockedIncrementVaultAmount = jest.spyOn(vaultService, 'incrementVaultAmount')
 
     return request(app.getHttpServer())
       .post(defaultStripeWebhookEndpoint)
@@ -325,20 +322,17 @@ describe('StripePaymentService', () => {
       targetVaultId: 'test-vault-id',
       amount: (mockInvoicePaidEvent.data.object as Stripe.Invoice).amount_paid,
       status: 'succeeded',
-      person: { firstName: "Full", lastName: "Name"},
+      person: { firstName: 'Full', lastName: 'Name' },
     } as Donation & { person: unknown })
 
-    prismaMock.vault.update.mockResolvedValue(
-      {campaignId: 'test-campaign'} as Vault
-    )
+    prismaMock.vault.update.mockResolvedValue({ campaignId: 'test-campaign' } as Vault)
 
     jest.spyOn(prismaMock, '$transaction').mockImplementation((callback) => callback(prismaMock))
     const mockedUpdateDonationPayment = jest
       .spyOn(campaignService, 'updateDonationPayment')
       .mockName('updateDonationPayment')
 
-    const mockedIncrementVaultAmount = jest
-      .spyOn(vaultService, 'incrementVaultAmount')
+    const mockedIncrementVaultAmount = jest.spyOn(vaultService, 'incrementVaultAmount')
 
     return request(app.getHttpServer())
       .post(defaultStripeWebhookEndpoint)
@@ -351,7 +345,7 @@ describe('StripePaymentService', () => {
         expect(mockedUpdateDonationPayment).toHaveBeenCalled()
         expect(prismaMock.donation.findUnique).toHaveBeenCalled()
         expect(prismaMock.donation.create).not.toHaveBeenCalled()
-        expect(prismaMock.donation.update).toHaveBeenCalledOnce()  //for the donation to succeeded
+        expect(prismaMock.donation.update).toHaveBeenCalledOnce() //for the donation to succeeded
         expect(mockedIncrementVaultAmount).toHaveBeenCalled()
         expect(mockedcreateDonationWish).toHaveBeenCalled()
       })

--- a/apps/api/src/donations/events/stripe-payment.service.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.ts
@@ -117,6 +117,7 @@ export class StripePaymentService {
       DonationStatus.succeeded,
       metadata,
     )
+
     //updateDonationPayment will mark the campaign as completed if amount is reached
     await this.checkForCompletedCampaign(metadata.campaignId)
 


### PR DESCRIPTION
## Motivation and context

Fixed: handling of stripe.charge.succeeded requires reading the amount from the incoming event not from the found in the database, because after payment-intent.create the amount is in waiting state with amount 0. 
Fixed the tests too.

