### PR TITLE
fix updating donation after charge succeeded event

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -630,7 +630,10 @@ export class CampaignService {
         })
 
         //if donation is switching to successful, increment the vault amount and send notification
-        if (newDonationStatus === DonationStatus.succeeded) {
+        if (
+          donation.status != DonationStatus.succeeded &&
+          newDonationStatus === DonationStatus.succeeded
+        ) {
           await this.vaultService.incrementVaultAmount(
             donation.targetVaultId,
             paymentData.netAmount,
@@ -743,8 +746,15 @@ export class CampaignService {
 
   async createDonationWish(wish: string, donationId: string, campaignId: string) {
     const person = await this.prisma.donation.findUnique({ where: { id: donationId } }).person()
-    await this.prisma.donationWish.create({
-      data: {
+    await this.prisma.donationWish.upsert({
+      where: { donationId },
+      create: {
+        message: wish,
+        donationId,
+        campaignId,
+        personId: person?.id,
+      },
+      update: {
         message: wish,
         donationId,
         campaignId,

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -631,7 +631,11 @@ export class CampaignService {
 
         //if donation is switching to successful, increment the vault amount and send notification
         if (newDonationStatus === DonationStatus.succeeded) {
-          await this.vaultService.incrementVaultAmount(donation.targetVaultId, paymentData.netAmount, tx)
+          await this.vaultService.incrementVaultAmount(
+            donation.targetVaultId,
+            paymentData.netAmount,
+            tx,
+          )
           this.notificationService.sendNotification('successfulDonation', {
             ...updatedDonation,
             person: updatedDonation.person,

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -631,7 +631,7 @@ export class CampaignService {
 
         //if donation is switching to successful, increment the vault amount and send notification
         if (newDonationStatus === DonationStatus.succeeded) {
-          await this.vaultService.incrementVaultAmount(donation.targetVaultId, donation.amount, tx)
+          await this.vaultService.incrementVaultAmount(donation.targetVaultId, paymentData.netAmount, tx)
           this.notificationService.sendNotification('successfulDonation', {
             ...updatedDonation,
             person: updatedDonation.person,

--- a/apps/api/src/donations/events/stripe-payment.service.spec.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.spec.ts
@@ -242,20 +242,17 @@ describe('StripePaymentService', () => {
       targetVaultId: 'test-vault-id',
       amount: (mockInvoicePaidEvent.data.object as Stripe.Invoice).amount_paid,
       status: 'succeeded',
-      person: { firstName: "Full", lastName: "Name"},
+      person: { firstName: 'Full', lastName: 'Name' },
     } as Donation & { person: unknown })
 
-    prismaMock.vault.update.mockResolvedValue(
-      {campaignId: 'test-campaign'} as Vault
-    )
+    prismaMock.vault.update.mockResolvedValue({ campaignId: 'test-campaign' } as Vault)
 
     jest.spyOn(prismaMock, '$transaction').mockImplementation((callback) => callback(prismaMock))
     const mockedUpdateDonationPayment = jest
       .spyOn(campaignService, 'updateDonationPayment')
       .mockName('updateDonationPayment')
 
-    const mockedIncrementVaultAmount = jest
-      .spyOn(vaultService, 'incrementVaultAmount')
+    const mockedIncrementVaultAmount = jest.spyOn(vaultService, 'incrementVaultAmount')
 
     return request(app.getHttpServer())
       .post(defaultStripeWebhookEndpoint)
@@ -325,20 +322,17 @@ describe('StripePaymentService', () => {
       targetVaultId: 'test-vault-id',
       amount: (mockInvoicePaidEvent.data.object as Stripe.Invoice).amount_paid,
       status: 'succeeded',
-      person: { firstName: "Full", lastName: "Name"},
+      person: { firstName: 'Full', lastName: 'Name' },
     } as Donation & { person: unknown })
 
-    prismaMock.vault.update.mockResolvedValue(
-      {campaignId: 'test-campaign'} as Vault
-    )
+    prismaMock.vault.update.mockResolvedValue({ campaignId: 'test-campaign' } as Vault)
 
     jest.spyOn(prismaMock, '$transaction').mockImplementation((callback) => callback(prismaMock))
     const mockedUpdateDonationPayment = jest
       .spyOn(campaignService, 'updateDonationPayment')
       .mockName('updateDonationPayment')
 
-    const mockedIncrementVaultAmount = jest
-      .spyOn(vaultService, 'incrementVaultAmount')
+    const mockedIncrementVaultAmount = jest.spyOn(vaultService, 'incrementVaultAmount')
 
     return request(app.getHttpServer())
       .post(defaultStripeWebhookEndpoint)
@@ -351,7 +345,7 @@ describe('StripePaymentService', () => {
         expect(mockedUpdateDonationPayment).toHaveBeenCalled()
         expect(prismaMock.donation.findUnique).toHaveBeenCalled()
         expect(prismaMock.donation.create).not.toHaveBeenCalled()
-        expect(prismaMock.donation.update).toHaveBeenCalledOnce()  //for the donation to succeeded
+        expect(prismaMock.donation.update).toHaveBeenCalledOnce() //for the donation to succeeded
         expect(mockedIncrementVaultAmount).toHaveBeenCalled()
         expect(mockedcreateDonationWish).toHaveBeenCalled()
       })

--- a/apps/api/src/donations/events/stripe-payment.service.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.ts
@@ -119,7 +119,7 @@ export class StripePaymentService {
     )
 
     //updateDonationPayment will mark the campaign as completed if amount is reached
-    await this.checkForCompletedCampaign(metadata.campaignId)
+    await this.cancelSubscriptionsIfCompletedCampaign(metadata.campaignId)
 
     //and finally save the donation wish
     if (donationId && metadata?.wish) {
@@ -307,11 +307,11 @@ export class StripePaymentService {
     )
 
     //updateDonationPayment will mark the campaign as completed if amount is reached
-    await this.checkForCompletedCampaign(metadata.campaignId)
+    await this.cancelSubscriptionsIfCompletedCampaign(metadata.campaignId)
   }
 
   //if the campaign is finished, we need to stop all active subscriptions
-  async checkForCompletedCampaign(campaignId: string) {
+  async cancelSubscriptionsIfCompletedCampaign(campaignId: string) {
     const updatedCampaign = await this.campaignService.getCampaignById(campaignId)
     if (updatedCampaign.state === CampaignState.complete) {
       const recurring =

--- a/apps/api/src/donations/events/stripe-payment.service.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.ts
@@ -117,6 +117,7 @@ export class StripePaymentService {
       DonationStatus.succeeded,
       metadata,
     )
+
     //updateDonationPayment will mark the campaign as completed if amount is reached
     await this.checkForCompletedCampaign(metadata.campaignId)
 

--- a/apps/api/src/prisma/prisma-client-exception.filter.ts
+++ b/apps/api/src/prisma/prisma-client-exception.filter.ts
@@ -67,11 +67,13 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
         return { property: el, children: [], constraints }
       })
 
-    response.status(status).json({
-      statusCode: status,
-      message,
-      error: this.cleanUpException(exception),
-    })
+    if (response) {
+      response.status(status).json({
+        statusCode: status,
+        message,
+        error: this.cleanUpException(exception),
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
## Motivation and context

Fixed updating an already succeeded donation was increasing the vault amount incorrectly

Side fixes:
- renamed function for readability
- fixed: prisma exception handling when response is undefined

