### PR TITLE
fixed handling of repeated charge.succeeded event

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -630,7 +630,10 @@ export class CampaignService {
         })
 
         //if donation is switching to successful, increment the vault amount and send notification
-        if (newDonationStatus === DonationStatus.succeeded) {
+        if (
+          donation.status != DonationStatus.succeeded &&
+          newDonationStatus === DonationStatus.succeeded
+        ) {
           await this.vaultService.incrementVaultAmount(
             donation.targetVaultId,
             paymentData.netAmount,
@@ -743,8 +746,15 @@ export class CampaignService {
 
   async createDonationWish(wish: string, donationId: string, campaignId: string) {
     const person = await this.prisma.donation.findUnique({ where: { id: donationId } }).person()
-    await this.prisma.donationWish.create({
-      data: {
+    await this.prisma.donationWish.upsert({
+      where: { donationId },
+      create: {
+        message: wish,
+        donationId,
+        campaignId,
+        personId: person?.id,
+      },
+      update: {
         message: wish,
         donationId,
         campaignId,

--- a/apps/api/src/donations/events/stripe-payment.service.ts
+++ b/apps/api/src/donations/events/stripe-payment.service.ts
@@ -119,7 +119,7 @@ export class StripePaymentService {
     )
 
     //updateDonationPayment will mark the campaign as completed if amount is reached
-    await this.checkForCompletedCampaign(metadata.campaignId)
+    await this.cancelSubscriptionsIfCompletedCampaign(metadata.campaignId)
 
     //and finally save the donation wish
     if (donationId && metadata?.wish) {
@@ -307,11 +307,11 @@ export class StripePaymentService {
     )
 
     //updateDonationPayment will mark the campaign as completed if amount is reached
-    await this.checkForCompletedCampaign(metadata.campaignId)
+    await this.cancelSubscriptionsIfCompletedCampaign(metadata.campaignId)
   }
 
   //if the campaign is finished, we need to stop all active subscriptions
-  async checkForCompletedCampaign(campaignId: string) {
+  async cancelSubscriptionsIfCompletedCampaign(campaignId: string) {
     const updatedCampaign = await this.campaignService.getCampaignById(campaignId)
     if (updatedCampaign.state === CampaignState.complete) {
       const recurring =

--- a/apps/api/src/prisma/prisma-client-exception.filter.ts
+++ b/apps/api/src/prisma/prisma-client-exception.filter.ts
@@ -67,11 +67,13 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
         return { property: el, children: [], constraints }
       })
 
-    response.status(status).json({
-      statusCode: status,
-      message,
-      error: this.cleanUpException(exception),
-    })
+    if (response) {
+      response.status(status).json({
+        statusCode: status,
+        message,
+        error: this.cleanUpException(exception),
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
## Motivation and context
Fixed: vault amount was incorrectly increased on updated donation with succeeded status. Now vault is increased only if status changes to succeeded.

Side fixes:
- renamed function for readability
- fixed prisma exception handler when response is undefined


