### PR TITLE
Fix a bug with the access to the expenses list of a campaign.

### DIFF
--- a/apps/api/src/campaign-file/campaign-file.controller.spec.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.spec.ts
@@ -48,7 +48,7 @@ describe('CampaignFileController', () => {
         ConfigService,
         {
           provide: CampaignService,
-          useValue: { getCampaignByIdAndCoordinatorId: jest.fn(() => null) },
+          useValue: { verifyCampaignOwner: jest.fn(() => null) },
         },
         VaultService,
         CampaignNewsService,
@@ -92,7 +92,7 @@ describe('CampaignFileController', () => {
     ).toEqual([fileId, fileId])
 
     expect(personService.findOneByKeycloakId).toHaveBeenCalledWith(userMock.sub)
-    expect(campaignService.getCampaignByIdAndCoordinatorId).not.toHaveBeenCalled()
+    expect(campaignService.verifyCampaignOwner).not.toHaveBeenCalled()
     expect(campaignFileService.create).toHaveBeenCalledTimes(2)
   })
 
@@ -102,16 +102,13 @@ describe('CampaignFileController', () => {
     await expect(controller.create(campaignId, { roles: [] }, [], userMock)).rejects.toThrowError()
 
     expect(personService.findOneByKeycloakId).toHaveBeenCalledWith(userMock.sub)
-    expect(campaignService.getCampaignByIdAndCoordinatorId).not.toHaveBeenCalled()
+    expect(campaignService.verifyCampaignOwner).not.toHaveBeenCalled()
   })
 
   it('should throw an error for user not owning updated campaign', async () => {
     await expect(controller.create(campaignId, { roles: [] }, [], userMock)).rejects.toThrowError()
 
     expect(personService.findOneByKeycloakId).toHaveBeenCalledWith(userMock.sub)
-    expect(campaignService.getCampaignByIdAndCoordinatorId).toHaveBeenCalledWith(
-      campaignId,
-      personIdMock,
-    )
+    expect(campaignService.verifyCampaignOwner).toHaveBeenCalledWith(campaignId, personIdMock)
   })
 })

--- a/apps/api/src/campaign-file/campaign-file.controller.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.ts
@@ -23,7 +23,7 @@ import { FilesRoleDto } from './dto/files-role.dto'
 import { CampaignFileService } from './campaign-file.service'
 import { CampaignService } from '../campaign/campaign.service'
 import { KeycloakTokenParsed, isAdmin } from '../auth/keycloak'
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger'
 import { CampaignFileRole } from '@prisma/client'
 
 @ApiTags('campaign-file')
@@ -51,10 +51,7 @@ export class CampaignFileController {
     }
 
     if (!isAdmin(user)) {
-      const campaign = await this.campaignService.getCampaignByIdAndCoordinatorId(
-        campaignId,
-        person.id,
-      )
+      const campaign = await this.campaignService.verifyCampaignOwner(campaignId, person.id)
       if (!campaign) {
         throw new NotFoundException(
           'User ' + user.name + 'is not admin or coordinator of campaign with id: ' + campaignId,
@@ -88,8 +85,8 @@ export class CampaignFileController {
       'Content-Type': file.mimetype,
       'Content-Disposition': 'attachment; filename="' + file.filename + '"',
       'Cache-Control': file.mimetype.startsWith('image/')
-                        ? 'public, s-maxage=15552000, stale-while-revalidate=15552000, immutable' 
-                        : 'no-store'
+        ? 'public, s-maxage=15552000, stale-while-revalidate=15552000, immutable'
+        : 'no-store',
     })
 
     return new StreamableFile(file.stream)


### PR DESCRIPTION
We used to honour only the coordinator, but the organizer is as important.

The expenses list was not visible before by the organizer of the campaign.