### PR TITLE
fixing concurency in donationWish seeding

### DIFF
--- a/db/seed/donationWish/factory.ts
+++ b/db/seed/donationWish/factory.ts
@@ -1,14 +1,14 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker'
+import { Prisma } from '@prisma/client'
 
-import { DonationWish } from '.prisma/client'
-
-export const donationWishFactory = Factory.define<DonationWish>(({ associations }) => ({
-  id: faker.datatype.uuid(),
-  message: faker.lorem.paragraph(),
-  campaignId: associations.campaignId || faker.datatype.uuid(),
-  personId: associations.personId || null,
-  donationId: associations.donationId || null,
-  createdAt: faker.date.past(),
-  updatedAt: faker.date.recent(),
-}))
+export const donationWishFactory = Factory.define<Prisma.DonationWishUncheckedCreateInput>(
+  ({ associations }) => ({
+    message: faker.lorem.paragraph(),
+    campaignId: associations.campaignId || faker.datatype.uuid(),
+    personId: associations.personId || null,
+    donationId: associations.donationId || null,
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.recent(),
+  }),
+)

--- a/db/seed/donationWish/seed.ts
+++ b/db/seed/donationWish/seed.ts
@@ -15,7 +15,7 @@ export async function donationsWishesSeed() {
     throw new Error('There are no donations created yet!')
   }
 
-  donations.forEach(async (donation) => {
+  for (const donation of donations) {
     const person = await prisma.person.findFirst()
     if (!person) {
       throw new Error('There are no people created yet!')
@@ -41,5 +41,5 @@ export async function donationsWishesSeed() {
     await prisma.donationWish.create({
       data: donationWishData,
     })
-  })
+  }
 }


### PR DESCRIPTION
## Motivation and context

It was reported that there is a unique constraint problem during seeding of DonationWishes.
Fixing by turning the donation loop into a sequential for loop.

