### PR TITLE
Reduce the cache ttl for public donations and total money collected.

### DIFF
--- a/apps/api/src/donations/donations.controller.ts
+++ b/apps/api/src/donations/donations.controller.ts
@@ -30,7 +30,7 @@ import { DonationQueryDto } from '../common/dto/donation-query-dto'
 import { CancelPaymentIntentDto } from './dto/cancel-payment-intent.dto'
 import { DonationsApiQuery } from './queries/donations.apiquery'
 import { PersonService } from '../person/person.service'
-import { CacheInterceptor } from '@nestjs/cache-manager'
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager'
 import { UseInterceptors } from '@nestjs/common'
 
 @ApiTags('donation')
@@ -111,6 +111,7 @@ export class DonationsController {
   }
 
   @Get('money')
+  @CacheTTL(5 * 1000)
   @UseInterceptors(CacheInterceptor)
   @Public()
   async totalDonatedMoney() {
@@ -126,6 +127,7 @@ export class DonationsController {
 
   @Get('listPublic')
   @UseInterceptors(CacheInterceptor)
+  @CacheTTL(2 * 1000)
   @Public()
   @ApiQuery({ name: 'campaignId', required: false, type: String })
   @ApiQuery({ name: 'status', required: false, enum: DonationStatus })


### PR DESCRIPTION
The idea of the cache is to help in extreme scenarios when many requests are being fired. 
One request every 2 seconds should be easy to handle by the backend.

## Motivation and context

Many people want to see their donation immediately after the payment.
With the 30 seconds cache - this was impossible and confusing. 

## Testing

Fired multiple requests and observed in the log that the actual db search is executed only once every 2 seconds for the public donations.