### PR TITLE
Validation of file types

### DIFF
--- a/apps/api/src/bank-transactions-file/bank-transactions-file.controller.ts
+++ b/apps/api/src/bank-transactions-file/bank-transactions-file.controller.ts
@@ -32,6 +32,7 @@ import {
   ImportStatus,
 } from '../bank-transactions-file/dto/bank-transactions-import-status.dto'
 import { CreateBankPaymentDto } from '../donations/dto/create-bank-payment.dto'
+import { validateFileType } from '../common/files'
 
 @ApiTags('bank-transactions-file')
 @Controller('bank-transactions-file')
@@ -45,7 +46,14 @@ export class BankTransactionsFileController {
   ) {}
 
   @Post(':bank_transactions_file_id')
-  @UseInterceptors(FilesInterceptor('file', 5, { limits: { fileSize: 10485760 } }))
+  @UseInterceptors(
+    FilesInterceptor('file', 5, {
+      limits: { fileSize: 1024 * 1024 * 10 }, //limit uploaded files to 5 at once and 10MB each
+      fileFilter: (_req: Request, file, cb) => {
+        validateFileType(file, cb)
+      },
+    }),
+  )
   async create(
     @Param('bank_transactions_file_id') bankTransactionsFileId: string,
     @Body() body: FilesTypesDto,

--- a/apps/api/src/campaign-file/campaign-file.controller.ts
+++ b/apps/api/src/campaign-file/campaign-file.controller.ts
@@ -24,6 +24,7 @@ import { CampaignFileService } from './campaign-file.service'
 import { CampaignService } from '../campaign/campaign.service'
 import { KeycloakTokenParsed, isAdmin } from '../auth/keycloak'
 import { ApiTags } from '@nestjs/swagger'
+import { validateFileType } from '../common/files'
 
 @ApiTags('campaign-file')
 @Controller('campaign-file')
@@ -35,7 +36,14 @@ export class CampaignFileController {
   ) {}
 
   @Post(':campaign_id')
-  @UseInterceptors(FilesInterceptor('file', 10, { limits: { fileSize: 20485760 } })) //limit uploaded files to 5 at once and 10MB each
+  @UseInterceptors(
+    FilesInterceptor('file', 10, {
+      limits: { fileSize: 1024 * 1024 * 10 }, //limit uploaded files to 10 at once and 10MB each
+      fileFilter: (_req: Request, file, cb) => {
+        validateFileType(file, cb)
+      },
+    }),
+  )
   async create(
     @Param('campaign_id') campaignId: string,
     @Body() body: FilesRoleDto,

--- a/apps/api/src/campaign-file/campaign-file.service.ts
+++ b/apps/api/src/campaign-file/campaign-file.service.ts
@@ -64,7 +64,7 @@ export class CampaignFileService {
       filename: encodeURIComponent(file.filename),
       mimetype: file.mimetype,
       stream: await this.s3.streamFile(this.bucketName, id),
-      role: file.role
+      role: file.role,
     }
   }
 

--- a/apps/api/src/campaign-news-file/campaign-news-file.controller.ts
+++ b/apps/api/src/campaign-news-file/campaign-news-file.controller.ts
@@ -24,6 +24,7 @@ import { FilesRoleDto } from './dto/files-role.dto'
 import { CampaignNewsFileService } from './campaign-news-file.service'
 import { KeycloakTokenParsed, isAdmin } from '../auth/keycloak'
 import { ApiTags } from '@nestjs/swagger'
+import { validateFileType } from '../common/files'
 
 @ApiTags('campaign-news-file')
 @Controller('campaign-news-file')
@@ -34,7 +35,14 @@ export class CampaignNewsFileController {
   ) {}
 
   @Post(':article_id')
-  @UseInterceptors(FilesInterceptor('file', 10, { limits: { fileSize: 20485760 } })) //limit uploaded files to 5 at once and 10MB each
+  @UseInterceptors(
+    FilesInterceptor('file', 10, {
+      limits: { fileSize: 1024 * 1024 * 10 }, //limit uploaded files to 10 at once and 10MB each
+      fileFilter: (_req: Request, file, cb) => {
+        validateFileType(file, cb)
+      },
+    }),
+  )
   async create(
     @Param('article_id') articleId: string,
     @Body() body: FilesRoleDto,

--- a/apps/api/src/common/files.ts
+++ b/apps/api/src/common/files.ts
@@ -24,6 +24,7 @@ export function validateFileType(
   const mimeAllowlist = [
     'text/plain',
     'application/json',
+    'application/pdf',
     'image/png',
     'image/jpeg',
     'application/xml',
@@ -36,7 +37,7 @@ export function validateFileType(
     return cb(new Error('File mime type is not allowed'), false)
   }
 
-  const allowedExtensions = /txt|json|jpeg|jpg|png|xml|xlsx|xls|docx/
+  const allowedExtensions = /txt|json|pdf|jpeg|jpg|png|xml|xlsx|xls|docx/
 
   const isExtensionSupported = allowedExtensions.test(path.extname(file.originalname).toLowerCase())
   if (!isExtensionSupported) {

--- a/apps/api/src/common/files.ts
+++ b/apps/api/src/common/files.ts
@@ -21,15 +21,17 @@ export function validateFileType(
   file: File,
   cb: (error: Error | null, acceptFile: boolean) => void,
 ) {
-  const allowedExtensions = /jpeg|jpg|png|xml|json|docx|txt/
+  const allowedExtensions = /txt|json|jpeg|jpg|png|xml|xlsx|xls|docx/
   const mimeAllowlist = [
+    'text/plain',
+    'application/json',
     'image/png',
     'image/jpeg',
     'application/xml',
     'text/xml',
-    'text/plain',
-    'application/json',
     'application/msword',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   ]
   const isExtensionSupported = allowedExtensions.test(path.extname(file.originalname).toLowerCase())
   if (!mimeAllowlist.includes(file.mimetype)) {

--- a/apps/api/src/common/files.ts
+++ b/apps/api/src/common/files.ts
@@ -1,0 +1,44 @@
+import path from 'path'
+
+interface File {
+  fieldname: string
+  originalname: string
+  encoding: string
+  mimetype: string
+  size: number
+  destination: string
+  filename: string
+  path: string
+  buffer: Buffer
+}
+
+/**
+ * The function validate is used the validate the type of a file using the file extension and MIME type
+ * @param file object that represent file
+ * @param cb callback function which indicates whether file is accepted or not
+ */
+export function validateFileType(
+  file: File,
+  cb: (error: Error | null, acceptFile: boolean) => void,
+) {
+  const allowedExtensions = /jpeg|jpg|png|xml|json|docx|txt/
+  const mimeAllowlist = [
+    'image/png',
+    'image/jpeg',
+    'application/xml',
+    'text/xml',
+    'text/plain',
+    'application/json',
+    'application/msword',
+  ]
+  const isExtensionSupported = allowedExtensions.test(path.extname(file.originalname).toLowerCase())
+  if (!mimeAllowlist.includes(file.mimetype)) {
+    return cb(new Error('File mime type is not allowed'), false)
+  }
+
+  if (!isExtensionSupported) {
+    return cb(new Error('File extension is not allowed'), false)
+  }
+
+  cb(null, true)
+}

--- a/apps/api/src/common/files.ts
+++ b/apps/api/src/common/files.ts
@@ -13,7 +13,7 @@ interface File {
 }
 
 /**
- * The function validate is used the validate the type of a file using the file extension and MIME type
+ * The function is used to validate the type of a file using the file extension and MIME type
  * @param file object that represent file
  * @param cb callback function which indicates whether file is accepted or not
  */
@@ -21,7 +21,6 @@ export function validateFileType(
   file: File,
   cb: (error: Error | null, acceptFile: boolean) => void,
 ) {
-  const allowedExtensions = /txt|json|jpeg|jpg|png|xml|xlsx|xls|docx/
   const mimeAllowlist = [
     'text/plain',
     'application/json',
@@ -33,11 +32,13 @@ export function validateFileType(
     'application/vnd.ms-excel',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   ]
-  const isExtensionSupported = allowedExtensions.test(path.extname(file.originalname).toLowerCase())
   if (!mimeAllowlist.includes(file.mimetype)) {
     return cb(new Error('File mime type is not allowed'), false)
   }
 
+  const allowedExtensions = /txt|json|jpeg|jpg|png|xml|xlsx|xls|docx/
+
+  const isExtensionSupported = allowedExtensions.test(path.extname(file.originalname).toLowerCase())
   if (!isExtensionSupported) {
     return cb(new Error('File extension is not allowed'), false)
   }

--- a/apps/api/src/irregularity-file/irregularity-file.controller.ts
+++ b/apps/api/src/irregularity-file/irregularity-file.controller.ts
@@ -20,7 +20,8 @@ import { PersonService } from '../person/person.service'
 import { IrregularityFileService } from './irregularity-file.service'
 import { RealmViewContactRequests, ViewContactRequests } from '@podkrepi-bg/podkrepi-types'
 import { IrregularityService } from '../irregularity/irregularity.service'
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger'
+import { validateFileType } from '../common/files'
 
 @ApiTags('irregularity-file')
 @Controller('irregularity-file')
@@ -33,7 +34,14 @@ export class IrregularityFileController {
 
   @Post(':irregularity_id')
   @Public()
-  @UseInterceptors(FilesInterceptor('file', 5, { limits: { fileSize: 10485760 } })) //limit uploaded files to 5 at once and 10MB each
+  @UseInterceptors(
+    FilesInterceptor('file', 5, {
+      limits: { fileSize: 1024 * 1024 * 10 }, //limit uploaded files to 5 at once and 10MB each
+      fileFilter: (_req: Request, file, cb) => {
+        validateFileType(file, cb)
+      },
+    }),
+  )
   async create(
     @Param('irregularity_id') irregularityId: string,
     @UploadedFiles() files: Express.Multer.File[],


### PR DESCRIPTION
Closes https://github.com/podkrepi-bg/api/issues/515
<!--- Provide a general summary of your changes in the Title above -->
This PR provides mechanism to validate the file type uploaded to the backend. I added two types of validation , since using only the extension is not secure enough. Now we will support the following extension and mime types:

```typescript
  const allowedExtensions = /txt|json|jpeg|jpg|png|xml|xlsx|xls|docx/
  const mimeAllowlist = [
    'text/plain',
    'application/json',
    'application/pdf',
    'image/png',
    'image/jpeg',
    'application/xml',
    'text/xml',
    'application/msword',
    'application/vnd.ms-excel',
    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
  ]
```

<!--- If it fixes an open issue, please link to the issue here. -->


## Motivation and context

<!--- Why is this change required? -->
<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->

## Testing
Tried to upload one valid and invalid file:
<img width="1243" alt="Screenshot 2023-11-03 at 21 40 24" src="https://github.com/podkrepi-bg/api/assets/44066540/2e98d518-dcb0-465d-99af-6e3cce01bde0">
Failed with:
<img width="892" alt="Screenshot 2023-11-03 at 21 40 45" src="https://github.com/podkrepi-bg/api/assets/44066540/715fac55-0d02-4f38-a8d3-998333070663">

Allowed mime type and not allowed extension:
<img width="1110" alt="Screenshot 2023-11-03 at 21 49 54" src="https://github.com/podkrepi-bg/api/assets/44066540/d58118ab-db9f-40f4-8b23-ea5374f75838">

<img width="850" alt="Screenshot 2023-11-03 at 21 50 04" src="https://github.com/podkrepi-bg/api/assets/44066540/5e658674-bf0b-4d9b-a9b9-6abfb54efb58">


