### PR TITLE
Made currency required in the API, cleaned up the create or connect

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -476,8 +476,8 @@ export class CampaignService {
     return this.prisma.campaign.create(createInput)
   }
 
-  async getCampaignVault(campaignId: string): Promise<Vault | null> {
-    return this.prisma.vault.findFirst({ where: { campaignId } })
+  async getCampaignVault(campaignId: string): Promise<Vault> {
+    return this.prisma.vault.findFirstOrThrow({ where: { campaignId } })
   }
 
   async getDonationsForCampaign(
@@ -695,15 +695,8 @@ export class CampaignService {
         newDonationStatus,
     )
 
-    /**
-     * Create or connect campaign vault
-     */
-    const vault = await tx.vault.findFirst({ where: { campaignId: campaign.id } })
-    const targetVaultData = vault
-      ? // Connect the existing vault to this donation
-        { connect: { id: vault.id } }
-      : // Create new vault for the campaign
-        { create: { campaignId: campaign.id, currency: campaign.currency, name: campaign.title } }
+    const vault = await tx.vault.findFirstOrThrow({ where: { campaignId: campaign.id } })
+    const targetVaultData = { connect: { id: vault.id } }
 
     try {
       const donation = await tx.donation.create({

--- a/apps/api/src/campaign/dto/create-campaign.dto.ts
+++ b/apps/api/src/campaign/dto/create-campaign.dto.ts
@@ -85,11 +85,7 @@ export class CreateCampaignDto {
   reachedAmount: number
 
   @ApiProperty()
-  @IsOptional()
   @Expose()
-  @IsString()
-  @MinLength(3)
-  @MaxLength(3)
   @IsEnum(Currency)
   currency: Currency
 

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -76,16 +76,6 @@ export class DonationsService {
       paymentIntentId,
     })
 
-    // /**
-    //  * Create or connect campaign vault
-    //  */
-    // const vault = await this.prisma.vault.findFirst({ where: { campaignId: campaign.id } })
-    // const targetVaultData = vault
-    //   ? // Connect the existing vault to this donation
-    //     { connect: { id: vault.id } }
-    //   : // Create new vault for the campaign
-    //     { create: { campaignId: campaign.id, currency: campaign.currency, name: campaign.title } }
-
     /**
      * Here we cannot create initial donation anymore because stripe is not returning paymentIntendId in the CreateSessionDto
      * It will be created in the paymentIntent.created webhook
@@ -107,15 +97,8 @@ export class DonationsService {
       paymentIntentId: paymentIntent.id,
     })
 
-    /**
-     * Create or connect campaign vault
-     */
-    const vault = await this.prisma.vault.findFirst({ where: { campaignId: campaign.id } })
-    const targetVaultData = vault
-      ? // Connect the existing vault to this donation
-        { connect: { id: vault.id } }
-      : // Create new vault for the campaign
-        { create: { campaignId: campaign.id, currency: campaign.currency, name: campaign.title } }
+    const vault = await this.campaignService.getCampaignVault(campaign.id)
+    const targetVaultData = { connect: { id: vault.id } }
 
     /**
      * Create or update initial donation object


### PR DESCRIPTION
* Set the `currency` as required when creating a new Campaign via the API
* Cleaned up the vault resolution logic (create or connect) - there is always a default vault created when a Campaign is created

Closes 420