### PR TITLE
src/campaign: Cache list endpoint

### DIFF
--- a/apps/api/src/campaign/campaign.controller.ts
+++ b/apps/api/src/campaign/campaign.controller.ts
@@ -31,6 +31,10 @@ import { ApiTags } from '@nestjs/swagger'
 import { CampaignNewsService } from '../campaign-news/campaign-news.service'
 import { CampaignSubscribeDto } from './dto/campaign-subscribe.dto'
 
+import { CacheInterceptor, CacheKey } from '@nestjs/cache-manager'
+import { UseInterceptors } from '@nestjs/common'
+import { CAMPAIGN_LIST } from '../common/cacheKeys'
+
 @ApiTags('campaign')
 @Controller('campaign')
 export class CampaignController {
@@ -41,6 +45,8 @@ export class CampaignController {
   ) {}
 
   @Get('list')
+  @UseInterceptors(CacheInterceptor)
+  @CacheKey(CAMPAIGN_LIST)
   @Public()
   async getData() {
     return this.campaignService.listCampaigns()

--- a/apps/api/src/common/cacheKeys.ts
+++ b/apps/api/src/common/cacheKeys.ts
@@ -1,0 +1,5 @@
+/**
+ * List of cache key definitions for manual manipulation(e.g. deleting, caching) etc..
+ */
+
+export const CAMPAIGN_LIST = 'campaignList'


### PR DESCRIPTION
On locally made tests, the average response time from this endpoint dropped from 60ms to 9-10ms. Theoretically it should also boost up the loading of index/campaigns pages on front-end, since the data is prefetched on the server-side(SSR)

Cache will be purged manually in the following scenarios: -Successful donation
-Successful refund
-Affiliate donation
-Bank import from iris


