### PR TITLE
Fix a bug with the files upload for the campaign expenses

### DIFF
--- a/apps/api/src/common/files.ts
+++ b/apps/api/src/common/files.ts
@@ -39,9 +39,15 @@ export function validateFileType(
 
   const allowedExtensions = /txt|json|pdf|jpeg|jpg|png|xml|xlsx|xls|docx/
 
-  const isExtensionSupported = allowedExtensions.test(path.extname(file.originalname).toLowerCase())
+  const filename = file.originalname
+  let ext = path.extname(filename).toLowerCase()
+  if (ext == '') {
+    // for the expense files, the original filename is encoded in base64
+    ext = path.extname(file.filename).toLowerCase()
+  }
+  const isExtensionSupported = allowedExtensions.test(ext)
   if (!isExtensionSupported) {
-    return cb(new Error('File extension is not allowed'), false)
+    return cb(new Error('File extension is not allowed: ' + file.filename), false)
   }
 
   cb(null, true)

--- a/apps/api/src/donations/donations.controller.ts
+++ b/apps/api/src/donations/donations.controller.ts
@@ -30,7 +30,7 @@ import { DonationQueryDto } from '../common/dto/donation-query-dto'
 import { CancelPaymentIntentDto } from './dto/cancel-payment-intent.dto'
 import { DonationsApiQuery } from './queries/donations.apiquery'
 import { PersonService } from '../person/person.service'
-import { CacheInterceptor } from '@nestjs/cache-manager'
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager'
 import { UseInterceptors } from '@nestjs/common'
 
 @ApiTags('donation')
@@ -111,6 +111,7 @@ export class DonationsController {
   }
 
   @Get('money')
+  @CacheTTL(5 * 1000)
   @UseInterceptors(CacheInterceptor)
   @Public()
   async totalDonatedMoney() {
@@ -126,6 +127,7 @@ export class DonationsController {
 
   @Get('listPublic')
   @UseInterceptors(CacheInterceptor)
+  @CacheTTL(2 * 1000)
   @Public()
   @ApiQuery({ name: 'campaignId', required: false, type: String })
   @ApiQuery({ name: 'status', required: false, enum: DonationStatus })

--- a/apps/api/src/expenses/expenses.controller.ts
+++ b/apps/api/src/expenses/expenses.controller.ts
@@ -10,6 +10,7 @@ import {
   StreamableFile,
   NotFoundException,
   UnauthorizedException,
+  Logger,
 } from '@nestjs/common'
 
 import { AuthenticatedUser, Public, RoleMatchingMode, Roles } from 'nest-keycloak-connect'
@@ -71,8 +72,15 @@ export class ExpensesController {
   @Post(':expenseId/files')
   @UseInterceptors(
     FilesInterceptor('file', 5, {
-      limits: { fileSize: 1024 * 1024 * 10 }, //limit uploaded files to 5 at once and 10MB each
+      limits: { fileSize: 1024 * 1024 * 30 }, //limit uploaded files to 5 at once and 30MB each
       fileFilter: (_req: Request, file, cb) => {
+        try {
+          // decode the name from base64
+          file.filename = Buffer.from(file.originalname, 'base64').toString('utf-8')
+        } catch {
+          Logger.error('Error decoding filename from base64: ', file.originalname)
+        }
+
         validateFileType(file, cb)
       },
     }),


### PR DESCRIPTION
The file upload was crashing, because it could not detect the file extension. 
The expense filenames are base64 encoded when they are uploaded.
This allows us to upload files with cyrilic names.
So we needed to decode the original name, before checking the extension.