### PR TITLE
src/donations: Allow status update from status declined

### DIFF
--- a/apps/api/src/donations/helpers/donation-status-updates.ts
+++ b/apps/api/src/donations/helpers/donation-status-updates.ts
@@ -5,13 +5,13 @@ const changeable: DonationStatus[] = [
   DonationStatus.incomplete,
   DonationStatus.paymentRequested,
   DonationStatus.waiting,
+  DonationStatus.declined,
   DonationStatus.guaranteed,
 ]
 const final: DonationStatus[] = [
   DonationStatus.succeeded,
   DonationStatus.cancelled,
   DonationStatus.deleted,
-  DonationStatus.declined,
   DonationStatus.invalid,
   DonationStatus.refund,
 ]


### PR DESCRIPTION
For some reason some donations from stripe are first with status declined, which later is updated to succeeded, but which we can't currently update. 