### PR TITLE
src/config: Set sentry's logLevels correctly

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -13,7 +13,7 @@ export default () => ({
     environment: process.env.APP_ENV,
     debug: false,
     enabled: process.env.APP_ENV !== 'development',
-    logLevel: 'debug',
+    logLevels: ['debug'],
     tracesSampleRate: 1.0,
   },
   sendgrid: {


### PR DESCRIPTION
logLevel has been deprecated in nestjs-sentry package, in favor of logLevels, which expects an array of Sentry LogLevels

Source:
https://github.com/ntegral/nestjs-sentry?tab=readme-ov-file#getting-started