### PR TITLE
donations/donation.service: Don't update the bank statement if exists

### DIFF
--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -642,10 +642,6 @@ export class DonationsService {
         return ImportStatus.SUCCESS
       }
 
-      await this.prisma.payment.update({
-        where: { extPaymentIntentId: donationDto.extPaymentIntentId },
-        data: { ...donationDto, updatedAt: existingDonation.updatedAt },
-      })
       return ImportStatus.UPDATED
     })
   }


### PR DESCRIPTION
Seems like the update statement is part of older implementation remove, and it causes new donation to be created everytime IRIS task runs.