### PR TITLE
campaign.service/updateDonationIfAllowed: Update donation amount aswell

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -642,6 +642,14 @@ export class CampaignService {
             extPaymentIntentId: paymentData.paymentIntentId,
             billingName: paymentData.billingName,
             billingEmail: paymentData.billingEmail,
+            donations: {
+              updateMany: {
+                where: { paymentId: payment.id },
+                data: {
+                  amount: paymentData.netAmount,
+                },
+              },
+            },
           },
           select: donationNotificationSelect,
         })


### PR DESCRIPTION
When payment via stripe is initially declined, the netAmount of the donation is 0. 
Ensure both payment and donations are updated if payment is updated to succeeded.
