### PR TITLE
src/donations: Set donation record date to payment's

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -647,6 +647,8 @@ export class CampaignService {
                 where: { paymentId: payment.id },
                 data: {
                   amount: paymentData.netAmount,
+                  createdAt: payment.createdAt,
+                  updatedAt: payment.updatedAt,
                 },
               },
             },

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -929,6 +929,8 @@ export class DonationsService {
         where: { id: donationId },
         data: {
           amount: payment.amount,
+          createdAt: payment.createdAt,
+          updatedAt: payment.updatedAt,
         },
       })
     })


### PR DESCRIPTION
When syncing donation with payment, use payment's createdAt , updatedAt params. 
This is due to us currently using updatedAt field, to list donations to campaign.