### PR TITLE
actions: Add seeding job to API test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
         run: yarn prisma generate
       - name: Migrate database
         run: yarn prisma migrate deploy
+      - name: Seed database
+        run: yarn seed
       - name: NX Build and lint API # https://github.com/marketplace/actions/nrwl-nx
         uses: MansaGroup/nrwl-nx-action@v3
         with:


### PR DESCRIPTION
Given the numerous times, we forget to update the seeding scripts, according to database schema changes, it would be better to add a Seed database job, to the API Test workflow, to catch those issues on PRs.