### PR TITLE
src/donations: Order public donations by createdAt property

### DIFF
--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -288,7 +288,7 @@ export class DonationsService {
           OR: [{ payment: { status: status } }, { payment: { status: PaymentStatus.guaranteed } }],
           targetVault: { campaignId },
         },
-        orderBy: [{ updatedAt: 'desc' }],
+        orderBy: [{ createdAt: 'desc' }],
         select: {
           id: true,
           type: true,

--- a/apps/api/src/tasks/bank-import/import-transactions.task.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.ts
@@ -520,6 +520,7 @@ export class IrisTasks {
         create: {
           amount: bankTransaction.amount,
           personId: null,
+          createdAt: new Date(bankTransaction.transactionDate),
           targetVaultId: vault.id,
           type: DonationType.donation,
         },

--- a/apps/api/src/tasks/bank-import/import-transactions.task.ts
+++ b/apps/api/src/tasks/bank-import/import-transactions.task.ts
@@ -520,7 +520,6 @@ export class IrisTasks {
         create: {
           amount: bankTransaction.amount,
           personId: null,
-          createdAt: new Date(bankTransaction.transactionDate),
           targetVaultId: vault.id,
           type: DonationType.donation,
         },

--- a/migrations/20240320171904_add_random_time_to_bank_payments/migration.sql
+++ b/migrations/20240320171904_add_random_time_to_bank_payments/migration.sql
@@ -1,0 +1,8 @@
+-- This is an empty migration.
+UPDATE donations
+SET created_at = donations.created_at::timestamp 
+                + (floor(random() * (23 - 1 + 1) + 1)::int || ' hours')::interval  
+                + (floor(random() * (59 - 1 + 1) + 1)::int || ' minutes')::interval 
+                + (floor(random() * (59 - 1 + 1) + 1)::int || ' seconds')::interval 
+                + (floor(random() * (999 - 1 + 1) + 100)::int || ' milliseconds')::interval
+FROM payments WHERE payments.id::text = donations.payment_id::text AND payments.provider::text = 'bank' AND donations.created_at::date < '2024-03-10'


### PR DESCRIPTION
Prior to the migration to new donation structure, bank donations had only date of transaction, and not hours, due to the response coming from IRIS, containing only a date. 
This has resulted in an edge-case, where some donation, were skipped, due to the pagination and order. A hacky solution was used by ordering donations via updatedAt property, but this has caused more troubles than fixing issues, as we need to ensure that updatedAt property is not updating on every update query.

The goal of this commit is to:
- Order public donations by createdAt property.
- Run migration script, which sets random hours, minutes, seconds and miliseconds, to current createdAt field, without touching the date.