### PR TITLE
src/donations: Fix stripe refund not working

### DIFF
--- a/apps/api/src/donations/donations.controller.ts
+++ b/apps/api/src/donations/donations.controller.ts
@@ -14,7 +14,7 @@ import {
   forwardRef,
 } from '@nestjs/common'
 import { ApiQuery, ApiTags } from '@nestjs/swagger'
-import { PaymentStatus } from '@prisma/client'
+
 import { AuthenticatedUser, Public, RoleMatchingMode, Roles } from 'nest-keycloak-connect'
 import {
   RealmViewSupporters,
@@ -195,10 +195,13 @@ export class DonationsController {
     )
   }
 
-  @Get(':id')
-  @Public()
-  findOne(@Param('id') id: string) {
-    return this.donationsService.getDonationById(id)
+  @Get('payments/:id')
+  @Roles({
+    roles: [RealmViewSupporters.role, ViewSupporters.role],
+    mode: RoleMatchingMode.ANY,
+  })
+  findOne(@Param('id') paymentId: string) {
+    return this.donationsService.getPaymentById(paymentId)
   }
 
   @Get('user/:id')

--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -482,12 +482,12 @@ export class DonationsService {
   }
 
   /**
-   *  Get donation by id
-   * @param id Donation id
-   * @returns  {Promise<Donation>} Donation
+   *  Get payment by id
+   * @param id payment id
+   * @returns  {Promise<PaymentWithDonation>} Payment
    * @throws NotFoundException if no donation is found
    */
-  async getDonationById(id: string): Promise<PaymentWithDonation> {
+  async getPaymentById(id: string): Promise<PaymentWithDonation> {
     try {
       const donation = await this.prisma.payment.findFirstOrThrow({
         where: { id },
@@ -788,7 +788,7 @@ export class DonationsService {
   async invalidate(id: string) {
     try {
       await this.prisma.$transaction(async (tx) => {
-        const donation = await this.getDonationById(id)
+        const donation = await this.getPaymentById(id)
 
         if (donation.status === PaymentStatus.succeeded) {
           await this.vaultService.decrementVaultAmount(


### PR DESCRIPTION
Appereantly the front-end, calls to not existing endpoint, when trying to retrieve payment by id.
- Changed the existing /donation/:id endpoint, to /donation/payment/:id.
- Switched endpoint from Public to protected, as the data retrieved from this endpoint is not really meant for public