### PR TITLE
fix: Extend campaign response to include organizer's company name

### DIFF
--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -398,7 +398,15 @@ export class CampaignService {
       organizer: {
         select: {
           id: true,
-          person: { select: { id: true, firstName: true, lastName: true, email: true } },
+          person: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              email: true,
+              company: { select: { id: true, companyName: true } },
+            },
+          },
         },
       },
       campaignFiles: true,

--- a/apps/api/src/organizer/organizer.service.ts
+++ b/apps/api/src/organizer/organizer.service.ts
@@ -13,7 +13,7 @@ export class OrganizerService {
   findAll() {
     return this.prisma.organizer.findMany({
       include: {
-        person: true,
+        person: { include: { company: { select: { id: true, companyName: true } } } },
         campaigns: { select: { id: true, slug: true } },
       },
     })

--- a/apps/api/src/person/person.service.ts
+++ b/apps/api/src/person/person.service.ts
@@ -78,6 +78,7 @@ export class PersonService {
         organizer: { select: { id: true } },
         coordinators: { select: { id: true } },
         beneficiaries: { select: { id: true } },
+        company: { select: { id: true, companyName: true } },
       },
     })
 


### PR DESCRIPTION
Extend campaign's API responses, to include necessary data, for usecases when corporation is organizer of a campaign.

Needed by [frontend#1760](https://github.com/podkrepi-bg/frontend/pull/1760)