### PR TITLE
src/campaign-news: Extend API response data to accomodate design changes

### DIFF
--- a/apps/api/src/campaign-news/campaign-news.controller.ts
+++ b/apps/api/src/campaign-news/campaign-news.controller.ts
@@ -71,12 +71,6 @@ export class CampaignNewsController {
     return await this.campaignNewsService.listAllArticles()
   }
 
-  @Get(':slug')
-  @Public()
-  async findOne(@Param('slug') slug: string) {
-    return await this.campaignNewsService.findArticleBySlug(slug)
-  }
-
   @Get('byId/:id')
   @Public()
   async findById(@Param('id') id: string) {

--- a/apps/api/src/campaign-news/campaign-news.service.ts
+++ b/apps/api/src/campaign-news/campaign-news.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, BadRequestException, NotFoundException } from '@nes
 import { CreateCampaignNewsDto } from './dto/create-campaign-news.dto'
 import { PrismaService } from '../prisma/prisma.service'
 import { UpdateCampaignNewsDto } from './dto/update-campaign-news.dto'
-import { CampaignNewsState } from '@prisma/client'
+import { CampaignFileRole, CampaignNewsState } from '@prisma/client'
 import { CampaignNews } from '../domain/generated/campaignNews/entities'
 import { SendGridParams } from '../notifications/providers/notifications.sendgrid.types'
 import { DateTime } from 'luxon'
@@ -160,12 +160,14 @@ export class CampaignNewsService {
           slug: true,
           author: true,
           publishedAt: true,
-          description: true,
           newsFiles: true,
           campaign: {
             select: {
               title: true,
               state: true,
+              slug: true,
+              campaignFiles: { where: { role: CampaignFileRole.campaignListPhoto } },
+              campaignType: { select: { category: true } },
             },
           },
         },
@@ -248,7 +250,24 @@ export class CampaignNewsService {
 
   async findArticleBySlug(slug: string) {
     return await this.prisma.campaignNews
-      .findFirst({ where: { slug: slug }, include: { newsFiles: true } })
+      .findFirst({
+        where: { slug: slug },
+        include: {
+          newsFiles: true,
+          campaign: {
+            select: {
+              id: true,
+              title: true,
+              targetAmount: true,
+              campaignType: { select: { category: true } },
+              state: true,
+              allowDonationOnComplete: true,
+              slug: true,
+              campaignFiles: { where: { role: CampaignFileRole.campaignListPhoto } },
+            },
+          },
+        },
+      })
       .catch((error) => Logger.warn(error))
   }
 

--- a/apps/api/src/campaign/campaign.controller.ts
+++ b/apps/api/src/campaign/campaign.controller.ts
@@ -71,6 +71,19 @@ export class CampaignController {
     return this.campaignNewsService.listPublishedNewsWithPagination(page)
   }
 
+  @Get('news/:articleSlug')
+  @Public()
+  async viewSingleCampaignArticle(@Param('articleSlug') articleSlug: string) {
+    const article = await this.campaignNewsService.findArticleBySlug(articleSlug)
+    if (!article) throw new NotFoundException(`Article with slug ${articleSlug} not found`)
+    const campaignSummary = await this.campaignService.getCampaignSums([article.campaignId])
+    article.campaign['summary'] = this.campaignService.getVaultAndDonationSummaries(
+      article.campaign.id,
+      campaignSummary,
+    )
+    return article
+  }
+
   @Get(':slug')
   @Public()
   async viewBySlug(@Param('slug') slug: string): Promise<{ campaign: Campaign | null }> {

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -1150,7 +1150,7 @@ export class CampaignService {
     })
   }
 
-  private getVaultAndDonationSummaries(campaignId: string, campaignSums: CampaignSummaryDto[]) {
+  getVaultAndDonationSummaries(campaignId: string, campaignSums: CampaignSummaryDto[]) {
     const csum = campaignSums.find((e) => e.id === campaignId)
     return {
       reachedAmount: csum?.reachedAmount || 0,


### PR DESCRIPTION
- Endpoint for single article has been moved from /campaign-news/:slug, to /campaign/news/:slug
- Included campaign's vault summary to /campaign/news/:slug response
- Included campaign's category, and campaignFile in /campaigns/news response