### PR TITLE
fix: Iris bank import failing due to long descriptions

### DIFF
--- a/migrations/20240515124820_change_bank_transaction_description_to_text/migration.sql
+++ b/migrations/20240515124820_change_bank_transaction_description_to_text/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "bank_transactions" ALTER COLUMN "description" SET DATA TYPE TEXT;

--- a/schema.prisma
+++ b/schema.prisma
@@ -625,7 +625,7 @@ model BankTransaction {
   recipientIban      String?             @map("recipient_iban") @db.VarChar(34)
   amount             Float               @default(0)
   currency           Currency            @default(BGN)
-  description        String              @db.VarChar(200)
+  description        String              @db.Text
   //Matched campaign payment code
   matchedRef         String?             @map("matched_ref") @db.VarChar(100)
   type               BankTransactionType


### PR DESCRIPTION
An issue was detected, where some descriptions of bank transactions exceed the column limit. Since we can't know for certain how long a description is going to be, change description column from Varchar to Text.