### PR TITLE
fix: Check if sendgrid list exists before attempting to create new one

### DIFF
--- a/apps/api/src/campaign/campaign.service.spec.ts
+++ b/apps/api/src/campaign/campaign.service.spec.ts
@@ -14,10 +14,11 @@ import { NotificationService } from '../sockets/notifications/notification.servi
 import { SendGridNotificationsProvider } from '../notifications/providers/notifications.sendgrid.provider'
 import { EmailService } from '../email/email.service'
 import { MarketingNotificationsService } from '../notifications/notifications.service'
+import { SendGridParams } from '../notifications/providers/notifications.sendgrid.types'
 
 describe('CampaignService', () => {
   let service: CampaignService
-  let marketing: NotificationsProviderInterface<unknown>
+  let marketing: NotificationsProviderInterface<SendGridParams>
 
   const mockCreateCampaign = {
     slug: 'test-slug',
@@ -121,6 +122,14 @@ describe('CampaignService', () => {
 
       jest.spyOn(marketing, 'createNewContactList').mockImplementation(async () => 'list-id')
       jest.spyOn(marketing, 'updateContactList').mockImplementation(async () => '')
+      jest.spyOn(marketing, 'getContactLists').mockResolvedValue({
+        statusCode: 200,
+        headers: '',
+        body: {
+          result: [],
+          _metadata: {},
+        },
+      })
       jest.spyOn(service, 'createCampaignNotificationList')
 
       expect(await service.update(mockUpdateCampaign.id, updateData, mockCampaign)).toEqual(
@@ -133,6 +142,7 @@ describe('CampaignService', () => {
         include: { campaignType: { select: { name: true, slug: true, category: true } } },
       })
       expect(service.createCampaignNotificationList).toHaveBeenCalledWith(updatedCampaign)
+
       expect(marketing.createNewContactList).toHaveBeenCalledWith({
         name: updatedCampaign.title,
       })

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -1040,7 +1040,7 @@ export class CampaignService {
     let listId: string
     const lists = await this.marketingNotificationsService.provider.getContactLists()
     const campaginEmailLists = lists.body.result
-    const exists = campaginEmailLists.find((campaign) => campaign.name === updated.title)
+    const exists = campaignEmailLists.find((campaign) => campaign.name === updated.title)
     if (exists) {
       listId = exists.id
     } else {

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -1037,7 +1037,7 @@ export class CampaignService {
 
   async createCampaignNotificationList(updated: { title: string; id: string }) {
     // Generate list in the marketing platform
-    let listId: string = ''
+    let listId: string
     const lists = await this.marketingNotificationsService.provider.getContactLists()
     const campaginEmailLists = lists.body.result
     const exists = campaginEmailLists.find((campaign) => campaign.name === updated.title)

--- a/apps/api/src/campaign/campaign.service.ts
+++ b/apps/api/src/campaign/campaign.service.ts
@@ -1037,9 +1037,17 @@ export class CampaignService {
 
   async createCampaignNotificationList(updated: { title: string; id: string }) {
     // Generate list in the marketing platform
-    const listId = await this.marketingNotificationsService.provider.createNewContactList({
-      name: updated.title || updated.id,
-    })
+    let listId: string = ''
+    const lists = await this.marketingNotificationsService.provider.getContactLists()
+    const campaginEmailLists = lists.body.result
+    const exists = campaginEmailLists.find((campaign) => campaign.name === updated.title)
+    if (exists) {
+      listId = exists.id
+    } else {
+      listId = await this.marketingNotificationsService.provider.createNewContactList({
+        name: updated.title || updated.id,
+      })
+    }
 
     const name = updated.title || ''
 

--- a/apps/api/src/notifications/providers/notifications.interface.providers.ts
+++ b/apps/api/src/notifications/providers/notifications.interface.providers.ts
@@ -19,6 +19,7 @@ type NotificationsInterfaceParams = {
   RemoveFromUnsubscribedRes: unknown
   AddToUnsubscribedRes: unknown
   SendNotificationRes: unknown
+  contactListsRes: unknown
 }
 
 export abstract class NotificationsProviderInterface<
@@ -35,4 +36,5 @@ export abstract class NotificationsProviderInterface<
     data: T['RemoveFromUnsubscribedParams'],
   ): Promise<T['RemoveFromUnsubscribedRes']>
   abstract sendNotification(data: T['SendNotificationParams']): Promise<T['SendNotificationRes']>
+  abstract getContactLists(): Promise<T['contactListsRes']>
 }

--- a/apps/api/src/notifications/providers/notifications.sendgrid.provider.ts
+++ b/apps/api/src/notifications/providers/notifications.sendgrid.provider.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import sgClient from '@sendgrid/client'
 import { NotificationsProviderInterface } from './notifications.interface.providers'
-import { SendGridParams } from './notifications.sendgrid.types'
+import { ContactListRes, SGClientResponse, SendGridParams } from './notifications.sendgrid.types'
 import { ClientRequest } from '@sendgrid/client/src/request'
 import { DateTime } from 'luxon'
 
@@ -25,6 +25,14 @@ export class SendGridNotificationsProvider
     }
   }
 
+  async getContactLists() {
+    const request = {
+      url: '/v3/marketing/lists',
+      method: 'GET',
+    } as ClientRequest
+    const [response] = await sgClient.request(request)
+    return response as SGClientResponse<ContactListRes>
+  }
   async createNewContactList(data: SendGridParams['CreateListParams']) {
     const request = {
       url: `/v3/marketing/lists`,

--- a/apps/api/src/notifications/providers/notifications.sendgrid.types.ts
+++ b/apps/api/src/notifications/providers/notifications.sendgrid.types.ts
@@ -1,4 +1,8 @@
+import { ClientResponse } from '@sendgrid/mail'
 import { MarketingTemplateHTMLFields } from '../marketing_templates/template.type'
+import Response from '@sendgrid/helpers/classes/response'
+
+export type SGClientResponse<T = object> = Response<T>
 
 export type SendGridParams = {
   // Parameters
@@ -22,6 +26,7 @@ export type SendGridParams = {
   RemoveFromUnsubscribedRes: unknown
   AddToUnsubscribedRes: unknown
   SendNotificationRes: unknown
+  contactListsRes: SGClientResponse<ContactListRes>
 
   // Implementation specific
   ContactData: ContactData
@@ -80,4 +85,16 @@ type SendNotificationParams = {
 // Reponses
 type GetContactsInfoRes = {
   [key: string]: { contact: { id: string; [key: string]: unknown; list_ids: string[] } }
+}
+
+type SendGridContactList = {
+  id: string
+  name: string
+  contact_count: number
+  _metadata: object
+}
+
+export type ContactListRes = {
+  result: SendGridContactList[]
+  _metadata: object
 }


### PR DESCRIPTION
For some reason,  campaigns' email list exists on sendgrid, but the data is not stored in the internal notification_list table. This behavior results in Bad Request whenever user attempts to subscribe for email notifications for a particular campaign , as we try to create two lists with the same name.

Closes [frontend#1170](https://github.com/podkrepi-bg/frontend/issues/1770)