### PR TITLE
fix(prisma): Set default Donation Type to donation

### DIFF
--- a/apps/api/src/domain/generated/donation/dto/create-donation.dto.ts
+++ b/apps/api/src/domain/generated/donation/dto/create-donation.dto.ts
@@ -1,7 +1,1 @@
-import { DonationType } from '@prisma/client'
-import { ApiProperty } from '@nestjs/swagger'
-
-export class CreateDonationDto {
-  @ApiProperty({ enum: DonationType })
-  type: DonationType
-}
+export class CreateDonationDto {}

--- a/apps/api/src/domain/generated/donation/dto/update-donation.dto.ts
+++ b/apps/api/src/domain/generated/donation/dto/update-donation.dto.ts
@@ -1,7 +1,1 @@
-import { DonationType } from '@prisma/client'
-import { ApiProperty } from '@nestjs/swagger'
-
-export class UpdateDonationDto {
-  @ApiProperty({ enum: DonationType })
-  type?: DonationType
-}
+export class UpdateDonationDto {}

--- a/migrations/20240517165753_set_default_donation_type/migration.sql
+++ b/migrations/20240517165753_set_default_donation_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "donations" ALTER COLUMN "type" SET DEFAULT 'donation';

--- a/podkrepi.dbml
+++ b/podkrepi.dbml
@@ -393,7 +393,7 @@ Table payments {
 Table donations {
   id String [pk]
   paymentId String [not null]
-  type DonationType [not null]
+  type DonationType [not null, default: 'donation']
   targetVaultId String [not null, note: 'Vault where the funds are going']
   amount Int [not null, default: 0]
   personId String

--- a/schema.prisma
+++ b/schema.prisma
@@ -475,7 +475,7 @@ model Donation {
   id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
 
   paymentId     String            @map("payment_id") @db.Uuid
-  type          DonationType
+  type          DonationType      @default(donation)
   /// Vault where the funds are going
   targetVaultId String            @map("target_vault_id") @db.Uuid
   amount        Int               @default(0)


### PR DESCRIPTION
There are recurring donations, created prior the implementation of the corporate flow, and thus resulting in an error when creating new donation, as type field is missing from the metadata. Set default value of DonationType to donation to prevent this.

