### PR TITLE
fix(prisma): Too many idle db connections

### DIFF
--- a/apps/api/src/affiliate/affiliate.module.ts
+++ b/apps/api/src/affiliate/affiliate.module.ts
@@ -2,14 +2,14 @@ import { Module } from '@nestjs/common'
 import { AffiliateController } from './affiliate.controller'
 import { AffiliateService } from './affiliate.service'
 import { PersonModule } from '../person/person.module'
-import { PrismaService } from '../prisma/prisma.service'
 import { DonationsModule } from '../donations/donations.module'
 import { CampaignModule } from '../campaign/campaign.module'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
   controllers: [AffiliateController],
-  providers: [AffiliateService, PrismaService],
-  imports: [PersonModule, DonationsModule, CampaignModule],
+  providers: [AffiliateService],
+  imports: [PersonModule, DonationsModule, CampaignModule, PrismaModule],
   exports: [AffiliateService],
 })
 export class AffiliateModule {}

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -61,6 +61,7 @@ import { StatisticsModule } from '../statistics/statistics.module'
 import { AffiliateModule } from '../affiliate/affiliate.module'
 
 import { LoggerModule } from '../logger/logger.module'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
   imports: [
@@ -130,7 +131,7 @@ import { LoggerModule } from '../logger/logger.module'
   controllers: [AppController],
   providers: [
     AppService,
-    PrismaService,
+    PrismaModule,
     EmailService,
     TemplateService,
     {

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -3,7 +3,6 @@ import { KeycloakConnectModule } from 'nest-keycloak-connect'
 
 import { AuthService } from './auth.service'
 import { LoginController } from './login.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { RegisterController } from './register.controller'
 import { AppConfigModule } from '../config/app-config.module'
 import { KeycloakConfigService } from '../config/keycloak-config.service'
@@ -15,10 +14,9 @@ import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
 import { MarketingNotificationsModule } from '../notifications/notifications.module'
 import { CompanyModule } from '../company/company.module'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
-  controllers: [LoginController, RegisterController, RefreshController, ProviderLoginController],
-  providers: [AuthService, PrismaService, EmailService, JwtService, TemplateService],
   imports: [
     AppConfigModule,
     HttpModule,
@@ -29,7 +27,10 @@ import { CompanyModule } from '../company/company.module'
     }),
     MarketingNotificationsModule,
     CompanyModule,
+    PrismaModule,
   ],
+  controllers: [LoginController, RegisterController, RefreshController, ProviderLoginController],
+  providers: [AuthService, EmailService, JwtService, TemplateService],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/apps/api/src/bank-transactions-file/bank-transactions-file.module.ts
+++ b/apps/api/src/bank-transactions-file/bank-transactions-file.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common'
 import { BankTransactionsFileService } from './bank-transactions-file.service'
 import { BankTransactionsFileController } from './bank-transactions-file.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { S3Service } from '../s3/s3.service'
 import { PersonService } from '../person/person.service'
 import { DonationsService } from '../donations/donations.service'
@@ -13,6 +12,7 @@ import { StripeConfigFactory } from '../donations/helpers/stripe-config-factory'
 import { ExportService } from '../export/export.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { MarketingNotificationsModule } from '../notifications/notifications.module'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
   imports: [
@@ -22,11 +22,11 @@ import { MarketingNotificationsModule } from '../notifications/notifications.mod
     }),
     NotificationModule,
     MarketingNotificationsModule,
+    PrismaModule,
   ],
   controllers: [BankTransactionsFileController],
   providers: [
     BankTransactionsFileService,
-    PrismaService,
     S3Service,
     PersonService,
     VaultService,

--- a/apps/api/src/bank-transactions/bank-transactions.module.ts
+++ b/apps/api/src/bank-transactions/bank-transactions.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common'
 import { CampaignModule } from '../campaign/campaign.module'
 import { DonationsModule } from '../donations/donations.module'
-import { PrismaService } from '../prisma/prisma.service'
 import { BankTransactionsController } from './bank-transactions.controller'
 import { BankTransactionsService } from './bank-transactions.service'
 import { ConfigModule } from '@nestjs/config'
@@ -11,6 +10,7 @@ import { HttpModule } from '@nestjs/axios'
 import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
 import { AffiliateModule } from '../affiliate/affiliate.module'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
   imports: [
@@ -20,9 +20,10 @@ import { AffiliateModule } from '../affiliate/affiliate.module'
     ExportModule,
     HttpModule,
     AffiliateModule,
+    PrismaModule,
   ],
   controllers: [BankTransactionsController],
-  providers: [BankTransactionsService, PrismaService, IrisTasks, EmailService, TemplateService], //TODO: Create Email module to not need to import each service
+  providers: [BankTransactionsService, IrisTasks, EmailService, TemplateService], //TODO: Create Email module to not need to import each service
   exports: [BankTransactionsService],
 })
 export class BankTransactionsModule {}

--- a/apps/api/src/bankaccount/bankaccount.module.ts
+++ b/apps/api/src/bankaccount/bankaccount.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { BankAccountService } from './bankaccount.service'
 import { BankAccountController } from './bankaccount.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [BankAccountController],
-  providers: [BankAccountService, PrismaService],
+  providers: [BankAccountService],
 })
 export class BankAccountModule {}

--- a/apps/api/src/benefactor/benefactor.module.ts
+++ b/apps/api/src/benefactor/benefactor.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { BenefactorService } from './benefactor.service'
 import { BenefactorController } from './benefactor.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [BenefactorController],
-  providers: [BenefactorService, PrismaService],
+  providers: [BenefactorService],
 })
 export class BenefactorModule {}

--- a/apps/api/src/beneficiary/beneficiary.module.ts
+++ b/apps/api/src/beneficiary/beneficiary.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
-import { PrismaService } from '../prisma/prisma.service'
 import { BeneficiaryController } from './beneficiary.controller'
 import { BeneficiaryService } from './beneficiary.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [BeneficiaryController],
-  providers: [BeneficiaryService, PrismaService],
+  providers: [BeneficiaryService],
 })
 export class BeneficiaryModule {}

--- a/apps/api/src/campaign-file/campaign-file.module.ts
+++ b/apps/api/src/campaign-file/campaign-file.module.ts
@@ -1,25 +1,18 @@
 import { Module } from '@nestjs/common'
 import { CampaignFileService } from './campaign-file.service'
 import { CampaignFileController } from './campaign-file.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { S3Service } from '../s3/s3.service'
 import { PersonService } from '../person/person.service'
 import { CampaignService } from '../campaign/campaign.service'
 import { VaultService } from '../vault/vault.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { MarketingNotificationsModule } from '../notifications/notifications.module'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
-  imports: [NotificationModule, MarketingNotificationsModule],
+  imports: [NotificationModule, MarketingNotificationsModule, PrismaModule],
 
   controllers: [CampaignFileController],
-  providers: [
-    CampaignFileService,
-    PrismaService,
-    S3Service,
-    PersonService,
-    CampaignService,
-    VaultService,
-  ],
+  providers: [CampaignFileService, S3Service, PersonService, CampaignService, VaultService],
 })
 export class CampaignFileModule {}

--- a/apps/api/src/campaign-news-file/campaign-news-file.module.ts
+++ b/apps/api/src/campaign-news-file/campaign-news-file.module.ts
@@ -5,11 +5,11 @@ import { CampaignNewsFileController } from './campaign-news-file.controller'
 import { S3Service } from '../s3/s3.service'
 import { PersonModule } from '../person/person.module'
 import { CampaignNewsModule } from '../campaign-news/campaign-news.module'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [CampaignNewsModule, PersonModule, PrismaModule],
   controllers: [CampaignNewsFileController],
-  imports: [CampaignNewsModule, PersonModule],
-  providers: [CampaignNewsFileService, PrismaService, S3Service],
+  providers: [CampaignNewsFileService, S3Service],
 })
 export class CampaignNewsFileModule {}

--- a/apps/api/src/campaign-news/campaign-news.module.ts
+++ b/apps/api/src/campaign-news/campaign-news.module.ts
@@ -1,16 +1,16 @@
 import { Module } from '@nestjs/common'
 import { CampaignNewsService } from './campaign-news.service'
 import { CampaignNewsController } from './campaign-news.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { PersonModule } from '../person/person.module'
 import { MarketingNotificationsModule } from '../notifications/notifications.module'
 import { ConfigService } from '@nestjs/config'
 import { EmailService } from '../email/email.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
-  imports: [PersonModule, MarketingNotificationsModule],
+  imports: [PersonModule, MarketingNotificationsModule, PrismaModule],
   controllers: [CampaignNewsController],
-  providers: [CampaignNewsService, PrismaService, ConfigService, EmailService],
+  providers: [CampaignNewsService, ConfigService, EmailService],
   exports: [CampaignNewsService],
 })
 export class CampaignNewsModule {}

--- a/apps/api/src/campaign-types/campaign-types.module.ts
+++ b/apps/api/src/campaign-types/campaign-types.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { CampaignTypesService } from './campaign-types.service'
 import { CampaignTypesController } from './campaign-types.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [CampaignTypesController],
-  providers: [CampaignTypesService, PrismaService],
+  providers: [CampaignTypesService],
 })
 export class CampaignTypesModule {}

--- a/apps/api/src/campaign/campaign.module.ts
+++ b/apps/api/src/campaign/campaign.module.ts
@@ -10,16 +10,18 @@ import { CampaignService } from './campaign.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { CampaignNewsModule } from '../campaign-news/campaign-news.module'
 import { MarketingNotificationsModule } from '../notifications/notifications.module'
+import { PrismaModule } from '../prisma/prisma.module'
 @Module({
   imports: [
     forwardRef(() => VaultModule),
     MarketingNotificationsModule,
     NotificationModule,
     CampaignNewsModule,
+    PrismaModule,
   ],
 
   controllers: [CampaignController, CampaignTypeController],
-  providers: [CampaignService, PrismaService, VaultService, PersonService, ConfigService],
+  providers: [CampaignService, VaultService, PersonService, ConfigService],
 
   exports: [CampaignService],
 })

--- a/apps/api/src/city/city.module.ts
+++ b/apps/api/src/city/city.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common'
 
 import { CityService } from './city.service'
 import { CityController } from './city.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [CityController],
-  providers: [CityService, PrismaService],
+  providers: [CityService],
 })
 export class CityModule {}

--- a/apps/api/src/company/company.module.ts
+++ b/apps/api/src/company/company.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common'
 import { CompanyService } from './company.service'
 import { CompanyController } from './company.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [CompanyController],
-  providers: [CompanyService, PrismaService],
+  providers: [CompanyService],
   exports: [CompanyService],
 })
 export class CompanyModule {}

--- a/apps/api/src/coordinator/coordinator.module.ts
+++ b/apps/api/src/coordinator/coordinator.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { CoordinatorService } from './coordinator.service'
 import { CoordinatorController } from './coordinator.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [CoordinatorController],
-  providers: [CoordinatorService, PrismaService],
+  providers: [CoordinatorService],
 })
 export class CoordinatorModule {}

--- a/apps/api/src/country/country.module.ts
+++ b/apps/api/src/country/country.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { CountryService } from './country.service'
 import { CountryController } from './country.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [CountryController],
-  providers: [CountryService, PrismaService],
+  providers: [CountryService],
 })
 export class CountryModule {}

--- a/apps/api/src/document/document.module.ts
+++ b/apps/api/src/document/document.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common'
 
 import { DocumentService } from './document.service'
 import { DocumentController } from './document.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [DocumentController],
-  providers: [DocumentService, PrismaService],
+  providers: [DocumentService],
 })
 export class DocumentModule {}

--- a/apps/api/src/donations/donations.module.ts
+++ b/apps/api/src/donations/donations.module.ts
@@ -19,6 +19,7 @@ import { ExportModule } from './../export/export.module'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { MarketingNotificationsModule } from '../notifications/notifications.module'
 import { EmailService } from '../email/email.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { EmailService } from '../email/email.service'
     ExportModule,
     NotificationModule,
     MarketingNotificationsModule,
+    PrismaModule,
   ],
   controllers: [DonationsController],
   providers: [
@@ -40,7 +42,6 @@ import { EmailService } from '../email/email.service'
     StripePaymentService,
     CampaignService,
     RecurringDonationService,
-    PrismaService,
     VaultService,
     PersonService,
     ExportService,

--- a/apps/api/src/expenses/expenses.module.ts
+++ b/apps/api/src/expenses/expenses.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common'
 import { ExpensesService } from './expenses.service'
 import { ExpensesController } from './expenses.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { S3Service } from '../s3/s3.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ExpensesController],
-  providers: [PrismaService, ExpensesService, S3Service],
+  providers: [ExpensesService, S3Service],
 })
 export class ExpensesModule {}

--- a/apps/api/src/info-request/info-request.module.ts
+++ b/apps/api/src/info-request/info-request.module.ts
@@ -6,16 +6,11 @@ import { SupportService } from '../support/support.service'
 import { EmailService } from '../email/email.service'
 import { TemplateService } from '../email/template.service'
 import { ConfigService } from '@nestjs/config'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [InfoRequestController],
-  providers: [
-    InfoRequestService,
-    PrismaService,
-    SupportService,
-    EmailService,
-    TemplateService,
-    ConfigService,
-  ],
+  providers: [InfoRequestService, SupportService, EmailService, TemplateService, ConfigService],
 })
 export class InfoRequestModule {}

--- a/apps/api/src/irregularity-file/irregularity-file.module.ts
+++ b/apps/api/src/irregularity-file/irregularity-file.module.ts
@@ -1,21 +1,15 @@
 import { Module } from '@nestjs/common'
 import { IrregularityFileService } from './irregularity-file.service'
 import { IrregularityFileController } from './irregularity-file.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { S3Service } from '../s3/s3.service'
 import { PersonService } from '../person/person.service'
 import { IrregularityService } from '../irregularity/irregularity.service'
 import { ConfigModule } from '@nestjs/config'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, PrismaModule],
   controllers: [IrregularityFileController],
-  providers: [
-    IrregularityFileService,
-    IrregularityService,
-    PrismaService,
-    S3Service,
-    PersonService,
-  ],
+  providers: [IrregularityFileService, IrregularityService, S3Service, PersonService],
 })
 export class IrregularityFileModule {}

--- a/apps/api/src/irregularity/irregularity.module.ts
+++ b/apps/api/src/irregularity/irregularity.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common'
 import { IrregularityService } from './irregularity.service'
 import { IrregularityController } from './irregularity.controller'
 import { IrregularityFileService } from '../irregularity-file/irregularity-file.service'
-import { PrismaService } from '../prisma/prisma.service'
 import { S3Service } from '../s3/s3.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [IrregularityController],
-  providers: [IrregularityService, PrismaService, IrregularityFileService, S3Service],
+  providers: [IrregularityService, IrregularityFileService, S3Service],
 })
 export class IrregularityModule {}

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -12,9 +12,10 @@ import { CampaignService } from '../campaign/campaign.service'
 import { VaultService } from '../vault/vault.service'
 import { NotificationService } from '../sockets/notifications/notification.service'
 import { NotificationGateway } from '../sockets/notifications/gateway'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, PrismaModule],
   providers: [
     {
       // Use the interface as token
@@ -22,7 +23,6 @@ import { NotificationGateway } from '../sockets/notifications/gateway'
       // But actually provide the service that implements the interface
       useClass: SendGridNotificationsProvider,
     },
-    PrismaService,
     PersonService,
     EmailService,
     TemplateService,
@@ -35,7 +35,6 @@ import { NotificationGateway } from '../sockets/notifications/gateway'
   ],
   controllers: [MarketingNotificationsController],
   exports: [
-    PrismaService,
     PersonService,
     EmailService,
     TemplateService,

--- a/apps/api/src/organizer/organizer.module.ts
+++ b/apps/api/src/organizer/organizer.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { OrganizerService } from './organizer.service'
 import { OrganizerController } from './organizer.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [OrganizerController],
-  providers: [OrganizerService, PrismaService],
+  providers: [OrganizerService],
 })
 export class OrganizerModule {}

--- a/apps/api/src/person/person.module.ts
+++ b/apps/api/src/person/person.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common'
 import { PersonService } from './person.service'
 import { PersonController } from './person.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { ConfigModule } from '@nestjs/config'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, PrismaModule],
   controllers: [PersonController],
-  providers: [PersonService, PrismaService],
+  providers: [PersonService],
   exports: [PersonService],
 })
 export class PersonModule {}

--- a/apps/api/src/prisma/prisma.module.ts
+++ b/apps/api/src/prisma/prisma.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { PrismaService } from './prisma.service'
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/apps/api/src/recurring-donation/recurring-donation.module.ts
+++ b/apps/api/src/recurring-donation/recurring-donation.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common'
 import { RecurringDonationService } from './recurring-donation.service'
 import { RecurringDonationController } from './recurring-donation.controller'
-import { PrismaService } from '../prisma/prisma.service'
 import { HttpModule } from '@nestjs/axios'
 import { StripeModule } from '@golevelup/nestjs-stripe'
 import { ConfigService } from '@nestjs/config'
 import { StripeConfigFactory } from '../donations/helpers/stripe-config-factory'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
   imports: [
@@ -14,9 +14,10 @@ import { StripeConfigFactory } from '../donations/helpers/stripe-config-factory'
       useFactory: StripeConfigFactory.useFactory,
     }),
     HttpModule,
+    PrismaModule,
   ],
 
   controllers: [RecurringDonationController],
-  providers: [PrismaService, RecurringDonationService],
+  providers: [RecurringDonationService],
 })
 export class RecurringDonationModule {}

--- a/apps/api/src/support/support.module.ts
+++ b/apps/api/src/support/support.module.ts
@@ -5,8 +5,10 @@ import { TemplateService } from '../email/template.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { SupportController } from './support.controller'
 import { SupportService } from './support.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [SupportController],
   providers: [SupportService, PrismaService, EmailService, TemplateService],
 })

--- a/apps/api/src/transfer/transfer.module.ts
+++ b/apps/api/src/transfer/transfer.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common'
 
-import { PrismaService } from '../prisma/prisma.service'
-
 import { TransferService } from './transfer.service'
 import { TransferController } from './transfer.controller'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [TransferController],
-  providers: [TransferService, PrismaService],
+  providers: [TransferService],
 })
 export class TransferModule {}

--- a/apps/api/src/vault/vault.module.ts
+++ b/apps/api/src/vault/vault.module.ts
@@ -3,16 +3,21 @@ import { ConfigService } from '@nestjs/config'
 import { CampaignModule } from '../campaign/campaign.module'
 import { CampaignService } from '../campaign/campaign.service'
 import { PersonService } from '../person/person.service'
-import { PrismaService } from '../prisma/prisma.service'
 import { VaultController } from './vault.controller'
 import { VaultService } from './vault.service'
 import { NotificationModule } from '../sockets/notifications/notification.module'
 import { MarketingNotificationsModule } from '../notifications/notifications.module'
+import { PrismaModule } from '../prisma/prisma.module'
 @Module({
-  imports: [forwardRef(() => CampaignModule), NotificationModule, MarketingNotificationsModule],
+  imports: [
+    forwardRef(() => CampaignModule),
+    NotificationModule,
+    MarketingNotificationsModule,
+    PrismaModule,
+  ],
 
   controllers: [VaultController],
-  providers: [VaultService, CampaignService, PrismaService, PersonService, ConfigService],
+  providers: [VaultService, CampaignService, PersonService, ConfigService],
   exports: [VaultService],
 })
 export class VaultModule {}

--- a/apps/api/src/withdrawal/withdrawal.module.ts
+++ b/apps/api/src/withdrawal/withdrawal.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { WithdrawalService } from './withdrawal.service'
 import { WithdrawalController } from './withdrawal.controller'
-import { PrismaService } from '../prisma/prisma.service'
+import { PrismaModule } from '../prisma/prisma.module'
 
 @Module({
+  imports: [PrismaModule],
   controllers: [WithdrawalController],
-  providers: [WithdrawalService, PrismaService],
+  providers: [WithdrawalService],
 })
 export class WithdrawalModule {}


### PR DESCRIPTION
When importing a service through the provider interface of the module, NestJS creates new instance each time that provider service is referenced. 

For example if we have 20 modules which have PrismaService as a provider, a 20 instances of PrismaService will be created, which could  result in many idle db connections.

To fix this:
- Added PrismaModule which would export PrismaService
- Replaced providers: [PrismaService] with imports: [PrismaModule] which ensures only a single instance of PrismaService is created.
