### PR TITLE
build: Change docker-compose to docker compose

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Copy env file
         run: cp .env.example .env
       - name: Run database
-        run: docker-compose up -d pg-db
+        run: docker compose up -d pg-db
       - name: Install dependencies 
         run: yarn install --immutable
       - name: Generate Prisma DB client


### PR DESCRIPTION
Docker v1 has been deprecated on ubuntu-latest, which breaks the CI.

Source:https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2
