### PR TITLE
fix: Connect non anonymous donation by personId

### DIFF
--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -914,7 +914,7 @@ export class DonationsService {
             create: {
               amount: paymentData.netAmount,
               type: paymentData.type as DonationType,
-              person: paymentData.personId ? { connect: { email: paymentData.billingEmail } } : {},
+              person: paymentData.personId ? { connect: { id: paymentData.personId } } : {},
               targetVault: targetVaultData,
             },
           },
@@ -928,7 +928,7 @@ export class DonationsService {
           donation.amount,
           tx,
         )
-        this.notificationService.sendNotification('successfulDonation', donation)
+        this.notificationService.sendNotification('successfulDonation', donation.donations[0])
       }
 
       return donation
@@ -966,7 +966,9 @@ export class DonationsService {
         },
         include: { donations: true },
       })
-      Logger.debug('Donation found by subscription: ', donation)
+      if (donation) {
+        Logger.debug('Donation found by subscription: ', donation)
+      }
     }
     return donation
   }

--- a/apps/api/src/sockets/notifications/notification.service.ts
+++ b/apps/api/src/sockets/notifications/notification.service.ts
@@ -9,11 +9,12 @@ export const donationNotificationSelect = Prisma.validator<Prisma.PaymentSelect>
   amount: true,
   extPaymentMethodId: true,
   createdAt: true,
-
   donations: {
     select: {
       id: true,
       targetVaultId: true,
+      createdAt: true,
+      amount: true,
       person: {
         select: {
           firstName: true,

--- a/apps/api/src/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/stripe/stripe.controller.spec.ts
@@ -34,7 +34,7 @@ describe('StripeController', () => {
     checkout: { sessions: { create: jest.fn() } },
     paymentIntents: { retrieve: jest.fn() },
     refunds: { create: jest.fn() },
-    setupIntents: { retrieve: jest.fn() },
+    setupIntents: { retrieve: jest.fn(), update: jest.fn() },
     customers: { create: jest.fn(), list: jest.fn() },
     paymentMethods: { attach: jest.fn() },
     products: { search: jest.fn(), create: jest.fn() },
@@ -199,7 +199,7 @@ describe('StripeController', () => {
       reason: 'requested_by_customer',
     })
   })
-  it(`should not call setupintents.update if campaign can't accept donations`, async () => {
+  it(`should not call setupintents.update if no campaignId is provided`, async () => {
     prismaMock.campaign.findFirst.mockResolvedValue({
       id: 'complete-campaign',
       allowDonationOnComplete: false,

--- a/apps/api/src/stripe/stripe.service.ts
+++ b/apps/api/src/stripe/stripe.service.ts
@@ -37,6 +37,9 @@ export class StripeService {
   ): Promise<Stripe.Response<Stripe.SetupIntent>> {
     if (!inputDto.metadata.campaignId)
       throw new BadRequestException('campaignId is missing from metadata')
+    await this.campaignService.validateCampaignId(
+      inputDto.metadata.campaignId as string,
+    )
     return await this.stripeClient.setupIntents.update(id, inputDto, { idempotencyKey })
   }
   /**

--- a/apps/api/src/stripe/stripe.service.ts
+++ b/apps/api/src/stripe/stripe.service.ts
@@ -37,9 +37,6 @@ export class StripeService {
   ): Promise<Stripe.Response<Stripe.SetupIntent>> {
     if (!inputDto.metadata.campaignId)
       throw new BadRequestException('campaignId is missing from metadata')
-    const campaign = await this.campaignService.validateCampaignId(
-      inputDto.metadata.campaignId as string,
-    )
     return await this.stripeClient.setupIntents.update(id, inputDto, { idempotencyKey })
   }
   /**


### PR DESCRIPTION
It is not necessary for the billlingEmail to be the one of the registered user(e.g. company emails for billing)
Fixed website donation message data via websocket