### PR TITLE
fix: Campaign application filename not encoded correctly

### DIFF
--- a/apps/api/src/campaign-application/campaign-application.service.ts
+++ b/apps/api/src/campaign-application/campaign-application.service.ts
@@ -320,8 +320,10 @@ export class CampaignApplicationService {
     personId: string,
     campaignApplicationId: string,
   ) {
+    
+    const decodedFilename = Buffer.from(file.originalname, 'base64').toString('utf-8')
     const fileDto: CreateCampaignApplicationFileDto = {
-      filename: file.originalname,
+      filename: decodedFilename,
       mimetype: file.mimetype,
       campaignApplicationId: campaignApplicationId,
       personId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When a file is uploaded with cyrilling name it is not being encoded correctly, due to multer encoding filenames to latin by default
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #682 

