### PR TITLE
fix(stripe-wh): Refund status not updated for payments via subscriptions

### DIFF
--- a/apps/api/src/donations/donations.service.ts
+++ b/apps/api/src/donations/donations.service.ts
@@ -400,12 +400,19 @@ export class DonationsService {
     }
   }
 
-  async getDonationByPaymentIntent(id: string): Promise<{ id: string } | null> {
+  async getDonationByPaymentIntent(id: string): Promise<{
+    id: string
+    targetVault: { campaign: Campaign } | null
+  } | null> {
     return await this.prisma.donation.findFirst({
       where: { payment: { extPaymentIntentId: id } },
-      select: { id: true },
+      select: {
+        id: true,
+        targetVault: { include: { campaign: true } },
+      },
     })
   }
+
   async getAffiliateDonationById(donationId: string, affiliateCode: string) {
     try {
       const donation = await this.prisma.payment.findFirstOrThrow({

--- a/apps/api/src/stripe/events/stripe-payment.service.spec.ts
+++ b/apps/api/src/stripe/events/stripe-payment.service.spec.ts
@@ -449,12 +449,14 @@ describe('StripePaymentService', () => {
       secret: stripeSecret,
     })
 
-    const campaignService = app.get<CampaignService>(CampaignService)
     const vaultService = app.get<VaultService>(VaultService)
 
-    const mockedCampaignById = jest
-      .spyOn(campaignService, 'getCampaignById')
-      .mockImplementation(() => Promise.resolve(mockedCampaign))
+    const mockedGetDonationByPaymentIntent = jest
+      .spyOn(donationService, 'getDonationByPaymentIntent')
+      .mockResolvedValue({
+        id: 'test-donation-id',
+        targetVault: { campaign: mockedCampaign },
+      })
 
     const paymentData = getPaymentDataFromCharge(
       mockChargeEventSucceeded.data.object as Stripe.Charge,
@@ -491,7 +493,9 @@ describe('StripePaymentService', () => {
       .send(payloadString)
       .expect(201)
       .then(() => {
-        expect(mockedCampaignById).toHaveBeenCalledWith(campaignId) //campaignId from the Stripe Event
+        expect(mockedGetDonationByPaymentIntent).toHaveBeenCalledWith(
+          'pi_3MmYVtKApGjVGa9t1BtdkBrz',
+        )
         expect(mockedUpdateDonationPayment).toHaveBeenCalled()
         expect(prismaMock.payment.findUnique).toHaveBeenCalled()
         expect(prismaMock.payment.create).not.toHaveBeenCalled()

--- a/apps/api/src/stripe/events/stripe-payment.service.ts
+++ b/apps/api/src/stripe/events/stripe-payment.service.ts
@@ -168,8 +168,7 @@ export class StripePaymentService {
 
     if (!campaign) {
       Logger.warn(
-        '[ handleRefundCreated ] No donation/campaign found for payment intent ' +
-          paymentIntentId,
+        '[ handleRefundCreated ] No donation/campaign found for payment intent ' + paymentIntentId,
       )
       return
     }

--- a/apps/api/src/stripe/events/stripe-payment.service.ts
+++ b/apps/api/src/stripe/events/stripe-payment.service.ts
@@ -18,7 +18,6 @@ import {
 import { PaymentStatus, CampaignState } from '@prisma/client'
 import { EmailService } from '../../email/email.service'
 import { RefundDonationEmailDto } from '../../email/template.interface'
-import { PrismaService } from '../../prisma/prisma.service'
 import { StripeService } from '../stripe.service'
 import { DonationsService } from '../../donations/donations.service'
 
@@ -162,16 +161,20 @@ export class StripePaymentService {
       chargePaymentIntent.metadata as StripeMetadata,
     )
 
-    const metadata: StripeMetadata = chargePaymentIntent.metadata as StripeMetadata
+    const paymentIntentId = chargePaymentIntent.payment_intent as string
 
-    if (!metadata.campaignId) {
-      Logger.debug('[ handleRefundCreated ] No campaignId in metadata ' + chargePaymentIntent.id)
+    const donation = await this.donationService.getDonationByPaymentIntent(paymentIntentId)
+    const campaign = donation?.targetVault?.campaign
+
+    if (!campaign) {
+      Logger.warn(
+        '[ handleRefundCreated ] No donation/campaign found for payment intent ' +
+          paymentIntentId,
+      )
       return
     }
 
     const billingData = getPaymentDataFromCharge(chargePaymentIntent)
-
-    const campaign = await this.campaignService.getCampaignById(metadata.campaignId)
 
     await this.donationService.updateDonationPayment(campaign, billingData, PaymentStatus.refund)
 


### PR DESCRIPTION
When payment is made via subscription, it does not contain metadata, resulting in the donation status not being updated when stripe webhook hits our API.