### PR TITLE
fix(stripe): Dont save payment method on subscription

### DIFF
--- a/apps/api/src/stripe/stripe.service.ts
+++ b/apps/api/src/stripe/stripe.service.ts
@@ -304,9 +304,6 @@ export class StripeService {
           },
         ],
         default_payment_method: paymentMethod.id,
-        payment_settings: {
-          save_default_payment_method: 'on_subscription',
-        },
         metadata: {
           type: metadata.type,
           campaignId: metadata.campaignId,


### PR DESCRIPTION
Not needed, we already handle the payment method manually.